### PR TITLE
Adding the EVcouplings model wrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 
 [project.optional-dependencies]
 evmutation2 = ["torch", "evmutation2"]
+evcouplings = ["evcouplings"]
 esm2 = ["torch", "transformers"]
 mpnn = ["torch", "prody"]
 umap = ["umap-learn"]

--- a/src/evedesign/models/evcouplings.py
+++ b/src/evedesign/models/evcouplings.py
@@ -78,7 +78,7 @@ class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
     supports_gpu_parallel: bool = False
     supports_cpu_parallel: bool = False
 
-    honors_precomputed_weights: bool = True
+    _honors_precomputed_weights: bool = True
 
     required_entity_attributes: list[str] | None = ["sequences"]
     optional_entity_attributes: list[str] | None = None
@@ -98,8 +98,9 @@ class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
             threshold are excluded from the fitted model and from positions()
         theta
             Sequence reweighting identity threshold; sequences with pairwise identity
-            >= theta are clustered and down-weighted. Only used when
-            provided Sequences carry no precomputed weights. None falls back to theta=0.8
+            >= theta are clustered and down-weighted. Only used when the provided
+            Sequences carry no precomputed weights. If theta is None and no precomputed
+            weights are available, build() raises a ValueError
         """
         if not self.available:
             raise ImportError(
@@ -248,10 +249,16 @@ class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
         )
 
         weights = target.sequences.weights
-        if weights is None and self.honors_precomputed_weights:
-            theta = self.theta if self.theta is not None else 0.8
-            target.sequences.compute_weights(theta=theta)
-            weights = target.sequences.weights
+
+        needs_theta = weights is None or not self._honors_precomputed_weights
+        if needs_theta and self.theta is None:
+            raise ValueError(
+                "Sequence reweighting requires either precomputed weights on the "
+                "provided Sequences or an explicit theta"
+            )
+
+        if weights is None and self._honors_precomputed_weights:
+            weights = target.sequences.compute_weights(theta=self.theta).weights
 
         self.model = self._fit(alignment, focus_id, num_model_positions, weights)
         self._index_list = np.asarray(self.model.index_list, dtype=int)
@@ -384,9 +391,6 @@ class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
         # full L x num_symbols delta-Hamiltonian matrix relative to this background
         delta = _single_mutant_hamiltonians(bg, model.J_ij, model.h_i)[:, :, FULL]
 
-        if invalid.any():
-            delta = np.full_like(delta, np.nan)
-
         # evedesign positions aligned with the model array order
         evc_positions = self._index_list - 1 + first_index
         pos_filter = set(positions) if positions is not None else None
@@ -474,15 +478,12 @@ class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
             bg_invalid = invalid.copy()
             bg_invalid[mi] = False
 
-            if bg_invalid.any():
-                logits = np.full(num_symbols, np.nan)
-            else:
-                logits = np.array([
-                    _delta_hamiltonian(
-                        np.array([mi]), np.array([symbol]), bg, model.J_ij, model.h_i
-                    )[FULL]
-                    for symbol in range(num_symbols)
-                ])
+            logits = np.array([
+                _delta_hamiltonian(
+                    np.array([mi]), np.array([symbol]), bg, model.J_ij, model.h_i
+                )[FULL]
+                for symbol in range(num_symbols)
+            ])
 
             rows.append(logits)
             index_tuples.append((inst_idx, int(entity), int(pos)))
@@ -513,7 +514,7 @@ class EVcouplingsMeanField(EVcouplings):
     EVcouplings model fitted with mean-field DCA
     """
     name: str = "EVcouplingsMeanField"
-    honors_precomputed_weights: bool = False
+    _honors_precomputed_weights: bool = False
 
     def __init__(
         self,
@@ -530,9 +531,8 @@ class EVcouplingsMeanField(EVcouplings):
             Alignment columns whose (unweighted) gap frequency strictly exceeds this
             threshold are excluded from the fitted model and from positions()
         theta
-            Sequence reweighting identity threshold; sequences with pairwise identity
-            >= theta are clustered and down-weighted. None falls back to the
-            MeanFieldDCA default (theta=0.8)
+            Sequence reweighting identity threshold. Sequences with pairwise identity
+            >= theta are clustered and down-weighted
         pseudo_count
             Pseudo-count for frequency regularization
         """
@@ -597,9 +597,8 @@ class EVcouplingsPLM(EVcouplings):
             threshold are excluded from the fitted model and from positions()
         theta
             Sequence reweighting identity threshold. Sequences with pairwise identity
-            >= theta are clustered and down-weighted. Only used as a fallback when the
-            provided Sequences carry no precomputed weights. None falls back to the
-            plmc default (theta=0.8)
+            >= theta are clustered and down-weighted. Used as a fallback when the
+            provided Sequences carry no precomputed weights
         lambda_h
             L2 regularisation strength on fields h_i
         lambda_J

--- a/src/evedesign/models/evcouplings.py
+++ b/src/evedesign/models/evcouplings.py
@@ -1,17 +1,21 @@
 """
-Wrapper class around the EVcouplings/EVmutation Potts model
+Wrapper classes around the EVcouplings/EVmutation Potts model
 
 This wrapper deliberately keeps only the two stages of the evcouplings pipeline that
 are relevant for modelling a single, already-aligned protein family inside evedesign:
 
 MSA construction is out of scope: the provided System is expected to already carry a MSA
 
-The plmc binary used by engine="plmc" is a separately-compiled C program that is not
-on PyPI (see https://github.com/debbiemarkslab/plmc) use engine="mean_field"
-to avoid external dependency
+Two concrete engines are provided as subclasses of the abstract EVcouplings base:
+
+EVcouplingsMeanField runs mean-field DCA and has no external dependency
+
+EVcouplingsPLM runs the pseudo-likelihood solver via the plmc binary, a program 
+that is not on PyPI (see https://github.com/debbiemarkslab/plmc). Use
+EVcouplingsMeanField to avoid the external dependency
 """
-import io
 import tempfile
+from abc import abstractmethod
 from os import PathLike
 from pathlib import Path
 from typing import Any, Literal, Self, Sequence
@@ -23,7 +27,7 @@ from evedesign.system import System, SystemInstance
 from evedesign.sequence import REMOVE_INSERTIONS_TRANSLATION
 from evedesign.constants import GAP, MASK
 from evedesign.types import StatusCallback
-from evedesign.utils import model_param_context, status_done, status_start
+from evedesign.utils import status_done, status_start
 
 try:
     from evcouplings.align.alignment import Alignment, ALPHABET_PROTEIN
@@ -37,7 +41,11 @@ except ImportError:
 
 class EVcouplings(BaseModel, Scorer):
     """
-    Wrapper around EVcouplings/EVmutation
+    Abstract base wrapper around EVcouplings/EVmutation
+
+    Holds all logic shared between the inference engines. Subclasses implement 
+    _fit() for a specific engine. Instantiate EVcouplingsPLM or EVcouplingsMeanField 
+    directly
     """
     available = IMPORT_AVAILABLE
     name: str = "EVcouplings"
@@ -57,72 +65,27 @@ class EVcouplings(BaseModel, Scorer):
     requires_gpu: bool = False
     supports_gpu: bool = False
     supports_gpu_parallel: bool = False
-    # plmc can be compiled w/ multi-core fitting
-    supports_cpu_parallel: bool = True
+    supports_cpu_parallel: bool = False
 
     required_entity_attributes: list[str] | None = ["sequences"]
     optional_entity_attributes: list[str] | None = None
 
     def __init__(
         self,
-        engine: Literal["plmc", "mean_field"] = "plmc",
         max_gap_fraction: float = 0.5,
         theta: float = 0.8,
-        lambda_h: float = 0.01,
-        lambda_J: float = 0.01,
-        lambda_J_times_Lq: bool = True,
-        lambda_group: float | None = None,
-        scale_clusters: float | None = None,
-        iterations: int | None = None,
-        ignore_gaps: bool = False,
-        pseudo_count: float = 0.5,
-        plmc_binary: str | PathLike = "plmc",
-        cpu: int | Literal["max"] | None = None,
-        keep_model_after_build: bool = False,
     ):
         """
-        Instantiate a new EVcouplings model.
+        Initialise the shared EVcouplings state.
 
         Parameters
         ----------
-        engine : {"plmc", "mean_field"}
-            Inference engine used during build(). "plmc" runs the pseudo-likelihood
-            solver (requires the external binary), "mean_field" runs mean-field DCA 
-            (no external binary).
         max_gap_fraction
             Alignment columns whose (unweighted) gap frequency strictly exceeds this
             threshold are excluded from the fitted model and from positions()
         theta
             Sequence reweighting identity threshold; sequences with pairwise identity
             >= theta are clustered and down-weighted. Used by both engines.
-        lambda_h
-            L2 regularisation strength on fields h_i (plmc only)
-        lambda_J
-            L2 regularisation strength on couplings J_ij (plmc only). If
-            lambda_J_times_Lq is True, this base value is scaled by
-            (num_symbols - 1)*(L - 1) (as in standard evcouplings)
-        lambda_J_times_Lq
-            Scale lambda_J by the number of states and modelled positions
-            (plmc only)
-        lambda_group
-            Group L1 regularisation strength on couplings (plmc only, None = plmc default)
-        scale_clusters
-            Scale weights of sequence clusters by this value (plmc only, None = plmc default)
-        iterations
-            Maximum optimization iterations (plmc only, None = plmc default)
-        ignore_gaps
-            If True, exclude gaps from parameter inference. Note that this also implies
-            gaps cannot be scored--the default (False) keeps gap as a model symbol
-        pseudo_count
-            Pseudo-count for frequency regularization (mean-field only)
-        plmc_binary
-            Path to / name of the plmc binary (engine="plmc" only)
-        cpu
-            Number of cores for plmc (requires OpenMP-compiled plmc) - or "max"
-        keep_model_after_build
-            If True, keep the parsed CouplingsModel in memory after build() to avoid
-            re-parsing on the first score() call. The compact binary parameters are always
-            retained regardless. Set to False for leaner serialization
         """
         if not self.available:
             raise ImportError(
@@ -130,41 +93,18 @@ class EVcouplings(BaseModel, Scorer):
                 "pip install evedesign[evcouplings]"
             )
 
-        if engine not in ("plmc", "mean_field"):
-            raise ValueError(f"Invalid engine '{engine}', valid options are 'plmc', 'mean_field'")
-
         if not 0.0 < max_gap_fraction <= 1.0:
             raise ValueError("max_gap_fraction must be in (0, 1]")
 
-        # most of these params are just defaults inherited from EVcouplings, leaving here
-        # in case users want to mess with them for some reason
-        self.engine = engine
         self.max_gap_fraction = max_gap_fraction
         self.theta = theta
-        self.lambda_h = lambda_h
-        self.lambda_J = lambda_J
-        self.lambda_J_times_Lq = lambda_J_times_Lq
-        self.lambda_group = lambda_group
-        self.scale_clusters = scale_clusters
-        self.iterations = iterations
-        self.ignore_gaps = ignore_gaps
-        self.pseudo_count = pseudo_count
-        self.plmc_binary = plmc_binary
-        self.cpu = cpu
-        self.keep_model_after_build = keep_model_after_build
-        # keep parsed parameters loaded across prediction calls by default
-        self.keep_model_after_pred = True
 
         self._system: System | None = None
 
-        # persistent (dill picklable) model state produced by build():
-        # compact plmc_v2 binary parameters
+        # parsed Potts model produced by build(); pickles directly with the wrapper
+        self.model: CouplingsModel | None = None
         # residue indices of the positions w/ enough coverage
-        self._model_bytes: bytes | None = None
         self._index_list: np.ndarray | None = None
-
-        # parsed CouplingsModel (reconstructed from _model_bytes on demand)
-        self._model: CouplingsModel | None = None
 
 
     @property
@@ -173,7 +113,7 @@ class EVcouplings(BaseModel, Scorer):
 
     @property
     def ready(self) -> bool:
-        return self._system is not None and self._model_bytes is not None
+        return self._system is not None and self.model is not None
 
     @classmethod
     def can_model(cls, system: System, data: Any = None) -> tuple[bool, str]:
@@ -196,16 +136,6 @@ class EVcouplings(BaseModel, Scorer):
             return False, "Provided sequences must be aligned"
 
         return True, ""
-
-
-    def _load_model(self) -> None:
-        # reconstruct parsed CouplingsModel from the stored binary parameters;
-        # a mean-field model is auto-detected and re-cast by CouplingsModel on read
-        if self._model is None:
-            self._model = CouplingsModel(io.BytesIO(self._model_bytes), file_format="plmc_v2")
-
-    def _delete_model(self) -> None:
-        self._model = None
 
 
     @staticmethod
@@ -265,58 +195,17 @@ class EVcouplings(BaseModel, Scorer):
         return alignment, excluded
 
 
-    def _fit_mean_field(self, alignment: "Alignment") -> bytes:
-        model = MeanFieldDCA(alignment).fit(
-            theta=self.theta, pseudo_count=self.pseudo_count
-        )
-        return self._model_to_bytes(model)
-
-    def _fit_plmc(self, alignment: "Alignment", focus_id: str, num_model_positions: int) -> bytes:
-        # scale lambda_J as in the standard couplings protocol
-        lambda_J = self.lambda_J
-        if self.lambda_J_times_Lq:
-            num_symbols = len(ALPHABET_PROTEIN) - (1 if self.ignore_gaps else 0)
-            lambda_J = lambda_J * (num_symbols - 1) * (num_model_positions - 1)
-
-        # writing temp files will be unavoidable if we want to limit
-        # the amount of code we copy from couplings
-        # although writing the alignment to file is super annoying
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp = Path(tmp)
-            aln_file = tmp / "alignment.fasta"
-            couplings_file = tmp / "couplings.txt"
-            param_file = tmp / "model.params"
-
-            with open(aln_file, "w") as f:
-                alignment.write(f, format="fasta")
-
-            run_plmc(
-                str(aln_file),
-                str(couplings_file),
-                param_file=str(param_file),
-                focus_seq=focus_id,
-                # None -> plmc default protein alphabet (gap included)
-                alphabet=None,
-                theta=self.theta,
-                scale=self.scale_clusters,
-                ignore_gaps=self.ignore_gaps,
-                iterations=self.iterations,
-                lambda_h=self.lambda_h,
-                lambda_J=lambda_J,
-                lambda_g=self.lambda_group,
-                cpu=self.cpu,
-                binary=str(self.plmc_binary),
-            )
-
-            return Path(param_file).read_bytes()
-
-    @staticmethod
-    def _model_to_bytes(model: "CouplingsModel") -> bytes:
-        """Serialise a CouplingsModel"""
-        with tempfile.TemporaryDirectory() as tmp:
-            out = Path(tmp) / "model.params"
-            model.to_file(str(out), file_format="plmc_v2")
-            return out.read_bytes()
+    @abstractmethod
+    def _fit(
+        self,
+        alignment: "Alignment",
+        focus_id: str,
+        num_model_positions: int,
+    ) -> "CouplingsModel":
+        """
+        Fit the engine-specific Potts model and return the parsed CouplingsModel.
+        """
+        raise NotImplementedError
 
 
     def build(
@@ -333,8 +222,7 @@ class EVcouplings(BaseModel, Scorer):
         target = system[0]
 
         # reset any previous fit
-        self._model = None
-        self._model_bytes = None
+        self.model = None
         self._index_list = None
 
         alignment, _ = self._build_alignment(target)
@@ -345,16 +233,8 @@ class EVcouplings(BaseModel, Scorer):
             np.array([c.isupper() and c != GAP for c in alignment[0]]).sum()
         )
 
-        if self.engine == "mean_field":
-            self._model_bytes = self._fit_mean_field(alignment)
-        else:
-            self._model_bytes = self._fit_plmc(alignment, focus_id, num_model_positions)
-
-        # parse once to capture the position numbering
-        self._load_model()
-        self._index_list = np.asarray(self._model.index_list, dtype=int)
-        if not self.keep_model_after_build:
-            self._delete_model()
+        self.model = self._fit(alignment, focus_id, num_model_positions)
+        self._index_list = np.asarray(self.model.index_list, dtype=int)
 
         status_done(status_callback, "EVcouplings model finished fitting")
 
@@ -397,22 +277,174 @@ class EVcouplings(BaseModel, Scorer):
         # map modelled residue numbers to 0-based positions in the (fixed-length) rep
         col_pos = self._index_list - first_index
 
-        with model_param_context(
-            self._load_model, self._delete_model, self.keep_model_after_pred
-        ):
-            subseqs = []
-            for instance in instances:
-                rep = instance[0].rep
-                subseq = "".join(str(c) for c in np.asarray(rep)[col_pos])
-                if MASK in subseq:
-                    raise ValueError(
-                        "Cannot score sequence containing mask symbol at a modelled position"
-                    )
-                subseqs.append(subseq)
+        subseqs = []
+        for instance in instances:
+            rep = instance[0].rep
+            subseq = "".join(str(c) for c in np.asarray(rep)[col_pos])
+            if MASK in subseq:
+                raise ValueError(
+                    "Cannot score sequence containing mask symbol at a modelled position"
+                )
+            subseqs.append(subseq)
 
-            # column 0 is the total Hamiltonian (J_ij + h_i sub-sums in columns 1, 2)
-            hamiltonians = self._model.hamiltonians(subseqs)[:, 0]
+        # column 0 is the total Hamiltonian (J_ij + h_i sub-sums in columns 1, 2)
+        hamiltonians = self.model.hamiltonians(subseqs)[:, 0]
 
         status_done(status_callback, "Scoring complete")
 
         return np.asarray(hamiltonians, dtype=float)
+
+
+class EVcouplingsMeanField(EVcouplings):
+    """
+    EVcouplings model fitted with mean-field DCA
+    """
+    name: str = "EVcouplingsMeanField"
+
+    def __init__(
+        self,
+        max_gap_fraction: float = 0.5,
+        theta: float = 0.8,
+        pseudo_count: float = 0.5,
+    ):
+        """
+        Instantiate a mean-field DCA EVcouplings model.
+
+        Parameters
+        ----------
+        max_gap_fraction
+            Alignment columns whose (unweighted) gap frequency strictly exceeds this
+            threshold are excluded from the fitted model and from positions()
+        theta
+            Sequence reweighting identity threshold; sequences with pairwise identity
+            >= theta are clustered and down-weighted
+        pseudo_count
+            Pseudo-count for frequency regularization
+        """
+        super().__init__(max_gap_fraction=max_gap_fraction, theta=theta)
+        self.pseudo_count = pseudo_count
+
+    def _fit(
+        self,
+        alignment: "Alignment",
+        focus_id: str,
+        num_model_positions: int,
+    ) -> "CouplingsModel":
+        return MeanFieldDCA(alignment).fit(
+            theta=self.theta, pseudo_count=self.pseudo_count
+        )
+
+
+class EVcouplingsPLM(EVcouplings):
+    """
+    EVcouplings model fitted with the plmc pseudo-likelihood solver
+
+    Requires the external plmc binary (https://github.com/debbiemarkslab/plmc)
+    """
+    name: str = "EVcouplingsPLM"
+    # plmc can be compiled w/ multi-core fitting
+    supports_cpu_parallel: bool = True
+
+    def __init__(
+        self,
+        max_gap_fraction: float = 0.5,
+        theta: float = 0.8,
+        lambda_h: float = 0.01,
+        lambda_J: float = 0.01,
+        lambda_J_times_Lq: bool = True,
+        lambda_group: float | None = None,
+        scale_clusters: float | None = None,
+        iterations: int | None = None,
+        ignore_gaps: bool = False,
+        plmc_binary: str | PathLike = "plmc",
+        cpu: int | Literal["max"] | None = None,
+    ):
+        """
+        Instantiate a plmc (pseudo-likelihood) EVcouplings model.
+
+        Parameters
+        ----------
+        max_gap_fraction
+            Alignment columns whose (unweighted) gap frequency strictly exceeds this
+            threshold are excluded from the fitted model and from positions()
+        theta
+            Sequence reweighting identity threshold; sequences with pairwise identity
+            >= theta are clustered and down-weighted
+        lambda_h
+            L2 regularisation strength on fields h_i
+        lambda_J
+            L2 regularisation strength on couplings J_ij. If lambda_J_times_Lq is True,
+            this base value is scaled by (num_symbols - 1)*(L - 1) (as in standard
+            evcouplings)
+        lambda_J_times_Lq
+            Scale lambda_J by the number of states and modelled positions
+        lambda_group
+            Group L1 regularisation strength on couplings (None = plmc default)
+        scale_clusters
+            Scale weights of sequence clusters by this value (None = plmc default)
+        iterations
+            Maximum optimization iterations (None = plmc default)
+        ignore_gaps
+            If True, exclude gaps from parameter inference. Note that this also implies
+            gaps cannot be scored--the default (False) keeps gap as a model symbol
+        plmc_binary
+            Path to / name of the plmc binary
+        cpu
+            Number of cores for plmc (requires OpenMP-compiled plmc) - or "max"
+        """
+        super().__init__(max_gap_fraction=max_gap_fraction, theta=theta)
+        # most of these params are just defaults inherited from EVcouplings, leaving here
+        # in case users want to mess with them for some reason
+        self.lambda_h = lambda_h
+        self.lambda_J = lambda_J
+        self.lambda_J_times_Lq = lambda_J_times_Lq
+        self.lambda_group = lambda_group
+        self.scale_clusters = scale_clusters
+        self.iterations = iterations
+        self.ignore_gaps = ignore_gaps
+        self.plmc_binary = plmc_binary
+        self.cpu = cpu
+
+    def _fit(
+        self,
+        alignment: "Alignment",
+        focus_id: str,
+        num_model_positions: int,
+    ) -> "CouplingsModel":
+        # scale lambda_J as in the standard couplings protocol
+        lambda_J = self.lambda_J
+        if self.lambda_J_times_Lq:
+            num_symbols = len(ALPHABET_PROTEIN) - (1 if self.ignore_gaps else 0)
+            lambda_J = lambda_J * (num_symbols - 1) * (num_model_positions - 1)
+
+        # writing temp files will be unavoidable if we want to limit
+        # the amount of code we copy from couplings
+        # although writing the alignment to file is super annoying
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            aln_file = tmp / "alignment.fasta"
+            couplings_file = tmp / "couplings.txt"
+            param_file = tmp / "model.params"
+
+            with open(aln_file, "w") as f:
+                alignment.write(f, format="fasta")
+
+            run_plmc(
+                str(aln_file),
+                str(couplings_file),
+                param_file=str(param_file),
+                focus_seq=focus_id,
+                # None -> plmc default protein alphabet (gap included)
+                alphabet=None,
+                theta=self.theta,
+                scale=self.scale_clusters,
+                ignore_gaps=self.ignore_gaps,
+                iterations=self.iterations,
+                lambda_h=self.lambda_h,
+                lambda_J=lambda_J,
+                lambda_g=self.lambda_group,
+                cpu=self.cpu,
+                binary=str(self.plmc_binary),
+            )
+
+            return CouplingsModel(str(param_file), file_format="plmc_v2")

--- a/src/evedesign/models/evcouplings.py
+++ b/src/evedesign/models/evcouplings.py
@@ -78,6 +78,8 @@ class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
     supports_gpu_parallel: bool = False
     supports_cpu_parallel: bool = False
 
+    honors_precomputed_weights: bool = True
+
     required_entity_attributes: list[str] | None = ["sequences"]
     optional_entity_attributes: list[str] | None = None
 
@@ -245,8 +247,11 @@ class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
             np.array([c.isupper() and c != GAP for c in alignment[0]]).sum()
         )
 
-        # prefer precomputed sequence weights; theta is only a fallback
         weights = target.sequences.weights
+        if weights is None and self.honors_precomputed_weights:
+            theta = self.theta if self.theta is not None else 0.8
+            target.sequences.compute_weights(theta=theta)
+            weights = target.sequences.weights
 
         self.model = self._fit(alignment, focus_id, num_model_positions, weights)
         self._index_list = np.asarray(self.model.index_list, dtype=int)
@@ -508,6 +513,7 @@ class EVcouplingsMeanField(EVcouplings):
     EVcouplings model fitted with mean-field DCA
     """
     name: str = "EVcouplingsMeanField"
+    honors_precomputed_weights: bool = False
 
     def __init__(
         self,
@@ -577,6 +583,7 @@ class EVcouplingsPLM(EVcouplings):
         scale_clusters: float | None = None,
         iterations: int | None = 100,
         ignore_gaps: bool = False,
+        independent_model: bool = False,
         plmc_binary: str | PathLike = "plmc",
         cpu: int | Literal["max"] | None = None,
     ):
@@ -611,6 +618,8 @@ class EVcouplingsPLM(EVcouplings):
         ignore_gaps
             If True, exclude gaps from parameter inference. Note that this also implies
             gaps cannot be scored--the default (False) keeps gap as a model symbol
+        independent_model
+            If True, fit an independent-site (no couplings) model
         plmc_binary
             Path to / name of the plmc binary
         cpu
@@ -626,6 +635,7 @@ class EVcouplingsPLM(EVcouplings):
         self.scale_clusters = scale_clusters
         self.iterations = iterations
         self.ignore_gaps = ignore_gaps
+        self.independent_model = independent_model
         self.plmc_binary = plmc_binary
         self.cpu = cpu
 
@@ -641,6 +651,8 @@ class EVcouplingsPLM(EVcouplings):
         if self.lambda_J_times_Lq:
             num_symbols = len(ALPHABET_PROTEIN) - (1 if self.ignore_gaps else 0)
             lambda_J = lambda_J * (num_symbols - 1) * (num_model_positions - 1)
+
+        iterations = 1 if self.independent_model else self.iterations
 
         # writing temp files will be unavoidable if we want to limit
         # the amount of code we copy from couplings
@@ -672,7 +684,7 @@ class EVcouplingsPLM(EVcouplings):
                     theta=self.theta if weights is None else None,
                     scale=self.scale_clusters,
                     ignore_gaps=self.ignore_gaps,
-                    iterations=self.iterations,
+                    iterations=iterations,
                     lambda_h=self.lambda_h,
                     lambda_J=lambda_J,
                     lambda_g=self.lambda_group,
@@ -689,4 +701,9 @@ class EVcouplingsPLM(EVcouplings):
                     ) from e
                 raise
 
-            return CouplingsModel(str(param_file), file_format="plmc_v2")
+            model = CouplingsModel(str(param_file), file_format="plmc_v2")
+
+        if self.independent_model:
+            model = model.to_independent_model()
+
+        return model

--- a/src/evedesign/models/evcouplings.py
+++ b/src/evedesign/models/evcouplings.py
@@ -1,0 +1,418 @@
+"""
+Wrapper class around the EVcouplings/EVmutation Potts model
+
+This wrapper deliberately keeps only the two stages of the evcouplings pipeline that
+are relevant for modelling a single, already-aligned protein family inside evedesign:
+
+MSA construction is out of scope: the provided System is expected to already carry a MSA
+
+The plmc binary used by engine="plmc" is a separately-compiled C program that is not
+on PyPI (see https://github.com/debbiemarkslab/plmc) use engine="mean_field"
+to avoid external dependency
+"""
+import io
+import tempfile
+from os import PathLike
+from pathlib import Path
+from typing import Any, Literal, Self, Sequence
+
+import numpy as np
+
+from evedesign.model import BaseModel, Scorer
+from evedesign.system import System, SystemInstance
+from evedesign.sequence import REMOVE_INSERTIONS_TRANSLATION
+from evedesign.constants import GAP, MASK
+from evedesign.types import StatusCallback
+from evedesign.utils import model_param_context, status_done, status_start
+
+try:
+    from evcouplings.align.alignment import Alignment, ALPHABET_PROTEIN
+    from evcouplings.couplings.mean_field import MeanFieldDCA
+    from evcouplings.couplings.model import CouplingsModel
+    from evcouplings.couplings.tools import run_plmc
+    IMPORT_AVAILABLE = True
+except ImportError:
+    IMPORT_AVAILABLE = False
+
+
+class EVcouplings(BaseModel, Scorer):
+    """
+    Wrapper around EVcouplings/EVmutation
+    """
+    available = IMPORT_AVAILABLE
+    name: str = "EVcouplings"
+    citations: list[str] = [
+        # EVmutation
+        "10.1038/nbt.3769",
+        # EVcouplings
+        "10.1093/bioinformatics/bty862",
+        # plmc ? idk if there is a paper
+    ]
+
+    # core properties
+    requires_target: bool = True
+    requires_fixed_length: bool = True
+    handles_deletions: bool = True
+    handles_insertions: bool = False
+    requires_gpu: bool = False
+    supports_gpu: bool = False
+    supports_gpu_parallel: bool = False
+    # plmc can be compiled w/ multi-core fitting
+    supports_cpu_parallel: bool = True
+
+    required_entity_attributes: list[str] | None = ["sequences"]
+    optional_entity_attributes: list[str] | None = None
+
+    def __init__(
+        self,
+        engine: Literal["plmc", "mean_field"] = "plmc",
+        max_gap_fraction: float = 0.5,
+        theta: float = 0.8,
+        lambda_h: float = 0.01,
+        lambda_J: float = 0.01,
+        lambda_J_times_Lq: bool = True,
+        lambda_group: float | None = None,
+        scale_clusters: float | None = None,
+        iterations: int | None = None,
+        ignore_gaps: bool = False,
+        pseudo_count: float = 0.5,
+        plmc_binary: str | PathLike = "plmc",
+        cpu: int | Literal["max"] | None = None,
+        keep_model_after_build: bool = False,
+    ):
+        """
+        Instantiate a new EVcouplings model.
+
+        Parameters
+        ----------
+        engine : {"plmc", "mean_field"}
+            Inference engine used during build(). "plmc" runs the pseudo-likelihood
+            solver (requires the external binary), "mean_field" runs mean-field DCA 
+            (no external binary).
+        max_gap_fraction
+            Alignment columns whose (unweighted) gap frequency strictly exceeds this
+            threshold are excluded from the fitted model and from positions()
+        theta
+            Sequence reweighting identity threshold; sequences with pairwise identity
+            >= theta are clustered and down-weighted. Used by both engines.
+        lambda_h
+            L2 regularisation strength on fields h_i (plmc only)
+        lambda_J
+            L2 regularisation strength on couplings J_ij (plmc only). If
+            lambda_J_times_Lq is True, this base value is scaled by
+            (num_symbols - 1)*(L - 1) (as in standard evcouplings)
+        lambda_J_times_Lq
+            Scale lambda_J by the number of states and modelled positions
+            (plmc only)
+        lambda_group
+            Group L1 regularisation strength on couplings (plmc only, None = plmc default)
+        scale_clusters
+            Scale weights of sequence clusters by this value (plmc only, None = plmc default)
+        iterations
+            Maximum optimization iterations (plmc only, None = plmc default)
+        ignore_gaps
+            If True, exclude gaps from parameter inference. Note that this also implies
+            gaps cannot be scored--the default (False) keeps gap as a model symbol
+        pseudo_count
+            Pseudo-count for frequency regularization (mean-field only)
+        plmc_binary
+            Path to / name of the plmc binary (engine="plmc" only)
+        cpu
+            Number of cores for plmc (requires OpenMP-compiled plmc) - or "max"
+        keep_model_after_build
+            If True, keep the parsed CouplingsModel in memory after build() to avoid
+            re-parsing on the first score() call. The compact binary parameters are always
+            retained regardless. Set to False for leaner serialization
+        """
+        if not self.available:
+            raise ImportError(
+                "evcouplings package could not be imported. Install w/"
+                "pip install evedesign[evcouplings]"
+            )
+
+        if engine not in ("plmc", "mean_field"):
+            raise ValueError(f"Invalid engine '{engine}', valid options are 'plmc', 'mean_field'")
+
+        if not 0.0 < max_gap_fraction <= 1.0:
+            raise ValueError("max_gap_fraction must be in (0, 1]")
+
+        # most of these params are just defaults inherited from EVcouplings, leaving here
+        # in case users want to mess with them for some reason
+        self.engine = engine
+        self.max_gap_fraction = max_gap_fraction
+        self.theta = theta
+        self.lambda_h = lambda_h
+        self.lambda_J = lambda_J
+        self.lambda_J_times_Lq = lambda_J_times_Lq
+        self.lambda_group = lambda_group
+        self.scale_clusters = scale_clusters
+        self.iterations = iterations
+        self.ignore_gaps = ignore_gaps
+        self.pseudo_count = pseudo_count
+        self.plmc_binary = plmc_binary
+        self.cpu = cpu
+        self.keep_model_after_build = keep_model_after_build
+        # keep parsed parameters loaded across prediction calls by default
+        self.keep_model_after_pred = True
+
+        self._system: System | None = None
+
+        # persistent (dill picklable) model state produced by build():
+        # compact plmc_v2 binary parameters
+        # residue indices of the positions w/ enough coverage
+        self._model_bytes: bytes | None = None
+        self._index_list: np.ndarray | None = None
+
+        # parsed CouplingsModel (reconstructed from _model_bytes on demand)
+        self._model: CouplingsModel | None = None
+
+
+    @property
+    def system(self) -> System | None:
+        return self._system
+
+    @property
+    def ready(self) -> bool:
+        return self._system is not None and self._model_bytes is not None
+
+    @classmethod
+    def can_model(cls, system: System, data: Any = None) -> tuple[bool, str]:
+        if data is not None:
+            return False, "Model does not support a data parameter (must be None)"
+
+        # will eventually include evcomplex, would have been kind of a lot of work
+        # and not sure if evedesign can handle paired MSA+instances without modification
+        if len(system) != 1 or system[0].type != "protein":
+            return False, "Can only handle a single-component protein system"
+
+        target = system[0]
+        if not target.defined_sequence():
+            return False, "Entity must have a defined rep sequence"
+
+        if target.sequences is None or len(target.sequences.seqs) == 0:
+            return False, "Must provide an MSA (entity.sequences) for model inference"
+
+        if not target.sequences.aligned:
+            return False, "Provided sequences must be aligned"
+
+        return True, ""
+
+
+    def _load_model(self) -> None:
+        # reconstruct parsed CouplingsModel from the stored binary parameters;
+        # a mean-field model is auto-detected and re-cast by CouplingsModel on read
+        if self._model is None:
+            self._model = CouplingsModel(io.BytesIO(self._model_bytes), file_format="plmc_v2")
+
+    def _delete_model(self) -> None:
+        self._model = None
+
+
+    @staticmethod
+    def _match_states(seq: str) -> str:
+        """Strip insertion states from an aligned sequence, leaving only match-state columns"""
+        return seq.translate(REMOVE_INSERTIONS_TRANSLATION)
+
+    def _build_alignment(self, target) -> tuple["Alignment", np.ndarray]:
+        """
+        Build an evcouplings Alignment from the system MSA and lower-case
+        the high-gap columns so they are excluded from the fit
+
+        Returns the (possibly modified) Alignment and the boolean mask of excluded columns
+        """
+        seqs = target.sequences.seqs
+        target_rep = "".join(target.rep)
+        length = len(target_rep)
+
+        match_seqs = [self._match_states(s.seq) for s in seqs]
+
+        bad = [i for i, m in enumerate(match_seqs) if len(m) != length]
+        if bad:
+            raise ValueError(
+                f"MSA match-state length does not match target length ({length}) "
+                f"for {len(bad)} sequence(s), e.g. sequence index {bad[0]}"
+            )
+
+        if match_seqs[0] != target_rep:
+            raise ValueError(
+                "First MSA sequence (match states) must equal the target/focus sequence. "
+                "EVcouplings requires the target sequence as the first alignment record"
+            )
+
+        first_index = target.first_index
+        focus_id = str(seqs[0].id_).split()[0]
+        ids = (
+            [f"{focus_id}/{first_index}-{first_index + length - 1}"]
+            + [str(s.id_) for s in seqs[1:]]
+        )
+
+        matrix = np.array([list(m) for m in match_seqs])
+        alignment = Alignment(matrix, sequence_ids=ids, alphabet=ALPHABET_PROTEIN)
+
+        # unweighted per-column gap frequency, exclude columns above the threshold
+        gap_freq = alignment.count(GAP, axis="pos", normalize=True)
+        excluded = gap_freq > self.max_gap_fraction
+
+        if excluded.all():
+            raise ValueError(
+                "All positions exceed max_gap_fraction, what are you aligning...?"
+            )
+
+        if excluded.any():
+            # lower-casing turns these into fake insert columns, which get stripped later
+            alignment = alignment.lowercase_columns(np.where(excluded)[0])
+
+        return alignment, excluded
+
+
+    def _fit_mean_field(self, alignment: "Alignment") -> bytes:
+        model = MeanFieldDCA(alignment).fit(
+            theta=self.theta, pseudo_count=self.pseudo_count
+        )
+        return self._model_to_bytes(model)
+
+    def _fit_plmc(self, alignment: "Alignment", focus_id: str, num_model_positions: int) -> bytes:
+        # scale lambda_J as in the standard couplings protocol
+        lambda_J = self.lambda_J
+        if self.lambda_J_times_Lq:
+            num_symbols = len(ALPHABET_PROTEIN) - (1 if self.ignore_gaps else 0)
+            lambda_J = lambda_J * (num_symbols - 1) * (num_model_positions - 1)
+
+        # writing temp files will be unavoidable if we want to limit
+        # the amount of code we copy from couplings
+        # although writing the alignment to file is super annoying
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            aln_file = tmp / "alignment.fasta"
+            couplings_file = tmp / "couplings.txt"
+            param_file = tmp / "model.params"
+
+            with open(aln_file, "w") as f:
+                alignment.write(f, format="fasta")
+
+            run_plmc(
+                str(aln_file),
+                str(couplings_file),
+                param_file=str(param_file),
+                focus_seq=focus_id,
+                # None -> plmc default protein alphabet (gap included)
+                alphabet=None,
+                theta=self.theta,
+                scale=self.scale_clusters,
+                ignore_gaps=self.ignore_gaps,
+                iterations=self.iterations,
+                lambda_h=self.lambda_h,
+                lambda_J=lambda_J,
+                lambda_g=self.lambda_group,
+                cpu=self.cpu,
+                binary=str(self.plmc_binary),
+            )
+
+            return Path(param_file).read_bytes()
+
+    @staticmethod
+    def _model_to_bytes(model: "CouplingsModel") -> bytes:
+        """Serialise a CouplingsModel"""
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "model.params"
+            model.to_file(str(out), file_format="plmc_v2")
+            return out.read_bytes()
+
+
+    def build(
+        self,
+        system: System,
+        data: None = None,
+        status_callback: StatusCallback | None = None,
+    ) -> Self:
+        self.can_model_or_raise(system, data)
+
+        status_start(status_callback, "Fitting EVcouplings model")
+
+        self._system = system
+        target = system[0]
+
+        # reset any previous fit
+        self._model = None
+        self._model_bytes = None
+        self._index_list = None
+
+        alignment, _ = self._build_alignment(target)
+
+        # number of modelled positions = match columns
+        focus_id = str(target.sequences.seqs[0].id_).split()[0]
+        num_model_positions = int(
+            np.array([c.isupper() and c != GAP for c in alignment[0]]).sum()
+        )
+
+        if self.engine == "mean_field":
+            self._model_bytes = self._fit_mean_field(alignment)
+        else:
+            self._model_bytes = self._fit_plmc(alignment, focus_id, num_model_positions)
+
+        # parse once to capture the position numbering
+        self._load_model()
+        self._index_list = np.asarray(self._model.index_list, dtype=int)
+        if not self.keep_model_after_build:
+            self._delete_model()
+
+        status_done(status_callback, "EVcouplings model finished fitting")
+
+        return self
+
+
+    def positions(
+        self,
+        instance: SystemInstance | None = None,
+    ) -> list[tuple[int, int]]:
+        """
+        Return the modelled positions (in entity 0). Positions excluded due to high gap
+        content are not part of the fitted model and are therefore not returned
+        """
+        self.ready_or_raise()
+        return [(0, int(pos)) for pos in self._index_list]
+
+
+    # elected to score full sequence to avoid dealing with indexing
+    def score(
+        self,
+        instances: Sequence[SystemInstance],
+        status_callback: StatusCallback | None = None,
+    ) -> np.ndarray:
+        """
+        Score full sequences by their statistical energy
+
+        Only the modelled (non-excluded) positions contribute, excluded positions are
+        ignored
+        """
+        self.ready_or_raise()
+        self._validate_instances(instances)
+
+        if len(instances) == 0:
+            return np.empty((0,), dtype=float)
+
+        status_start(status_callback, "Scoring sequences")
+
+        first_index = self.system[0].first_index
+        # map modelled residue numbers to 0-based positions in the (fixed-length) rep
+        col_pos = self._index_list - first_index
+
+        with model_param_context(
+            self._load_model, self._delete_model, self.keep_model_after_pred
+        ):
+            subseqs = []
+            for instance in instances:
+                rep = instance[0].rep
+                subseq = "".join(str(c) for c in np.asarray(rep)[col_pos])
+                if MASK in subseq:
+                    raise ValueError(
+                        "Cannot score sequence containing mask symbol at a modelled position"
+                    )
+                subseqs.append(subseq)
+
+            # column 0 is the total Hamiltonian (J_ij + h_i sub-sums in columns 1, 2)
+            hamiltonians = self._model.hamiltonians(subseqs)[:, 0]
+
+        status_done(status_callback, "Scoring complete")
+
+        return np.asarray(hamiltonians, dtype=float)

--- a/src/evedesign/models/evcouplings.py
+++ b/src/evedesign/models/evcouplings.py
@@ -14,6 +14,7 @@ EVcouplingsPLM runs the pseudo-likelihood solver via the plmc binary, a program
 that is not on PyPI (see https://github.com/debbiemarkslab/plmc). Use
 EVcouplingsMeanField to avoid the external dependency
 """
+import shutil
 import tempfile
 from abc import abstractmethod
 from os import PathLike
@@ -571,7 +572,7 @@ class EVcouplingsPLM(EVcouplings):
         lambda_J_times_Lq: bool = True,
         lambda_group: float | None = None,
         scale_clusters: float | None = None,
-        iterations: int | None = None,
+        iterations: int | None = 100,
         ignore_gaps: bool = False,
         plmc_binary: str | PathLike = "plmc",
         cpu: int | Literal["max"] | None = None,
@@ -601,7 +602,8 @@ class EVcouplingsPLM(EVcouplings):
         scale_clusters
             Scale weights of sequence clusters by this value (None = plmc default)
         iterations
-            Maximum optimization iterations (None = plmc default)
+            Maximum L-BFGS iterations. Defaults to 100 (the standard EVcouplings
+            cap?) None = plmc default
         ignore_gaps
             If True, exclude gaps from parameter inference. Note that this also implies
             gaps cannot be scored--the default (False) keeps gap as a model symbol
@@ -622,6 +624,13 @@ class EVcouplingsPLM(EVcouplings):
         self.ignore_gaps = ignore_gaps
         self.plmc_binary = plmc_binary
         self.cpu = cpu
+
+        if shutil.which(str(plmc_binary)) is None:
+            raise FileNotFoundError(
+                f"plmc binary not found or not executable: {plmc_binary!r}. "
+                "Pass the path to the compiled plmc executable (ex. "
+                "/path/to/plmc/bin/plmc)"
+            )
 
     def _fit(
         self,

--- a/src/evedesign/models/evcouplings.py
+++ b/src/evedesign/models/evcouplings.py
@@ -14,7 +14,6 @@ EVcouplingsPLM runs the pseudo-likelihood solver via the plmc binary, a program
 that is not on PyPI (see https://github.com/debbiemarkslab/plmc). Use
 EVcouplingsMeanField to avoid the external dependency
 """
-import shutil
 import tempfile
 from abc import abstractmethod
 from os import PathLike
@@ -23,6 +22,7 @@ from typing import Any, Literal, Self, Sequence
 
 import numpy as np
 import pandas as pd
+from loguru import logger
 
 from evedesign.model import (
     BaseModel,
@@ -46,6 +46,7 @@ try:
         FULL,
     )
     from evcouplings.couplings.tools import run_plmc
+    from evcouplings.utils.system import ExternalToolError
     IMPORT_AVAILABLE = True
 except ImportError:
     IMPORT_AVAILABLE = False
@@ -83,7 +84,7 @@ class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
     def __init__(
         self,
         max_gap_fraction: float = 0.5,
-        theta: float = 0.8,
+        theta: float | None = None,
     ):
         """
         Initialise the shared EVcouplings state.
@@ -96,7 +97,7 @@ class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
         theta
             Sequence reweighting identity threshold; sequences with pairwise identity
             >= theta are clustered and down-weighted. Only used when
-            provided Sequences carry no precomputed weights
+            provided Sequences carry no precomputed weights. None falls back to theta=0.8
         """
         if not self.available:
             raise ImportError(
@@ -294,10 +295,6 @@ class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
         for instance in instances:
             rep = instance[0].rep
             subseq = "".join(str(c) for c in np.asarray(rep)[col_pos])
-            if MASK in subseq:
-                raise ValueError(
-                    "Cannot score sequence containing mask symbol at a modelled position"
-                )
             subseqs.append(subseq)
 
         # column 0 is the total Hamiltonian (J_ij + h_i sub-sums in columns 1, 2)
@@ -515,7 +512,7 @@ class EVcouplingsMeanField(EVcouplings):
     def __init__(
         self,
         max_gap_fraction: float = 0.5,
-        theta: float = 0.8,
+        theta: float | None = None,
         pseudo_count: float = 0.5,
     ):
         """
@@ -528,7 +525,8 @@ class EVcouplingsMeanField(EVcouplings):
             threshold are excluded from the fitted model and from positions()
         theta
             Sequence reweighting identity threshold; sequences with pairwise identity
-            >= theta are clustered and down-weighted
+            >= theta are clustered and down-weighted. None falls back to the
+            MeanFieldDCA default (theta=0.8)
         pseudo_count
             Pseudo-count for frequency regularization
         """
@@ -542,11 +540,16 @@ class EVcouplingsMeanField(EVcouplings):
         num_model_positions: int,
         weights: Sequence[float] | None = None,
     ) -> "CouplingsModel":
-        # mean-field DCA does not yet support precomputed weights, so it always
-        # reweights via theta (the precomputed Sequences weights are ignored here)
-        return MeanFieldDCA(alignment).fit(
-            theta=self.theta, pseudo_count=self.pseudo_count
-        )
+        if weights is not None:
+            logger.warning(
+                "EVcouplingsMeanField does not support precomputed sequence weights. "
+                "The provided weights will be ignored and weights will be recomputed "
+                "from theta."
+            )
+        fit_kwargs = {"pseudo_count": self.pseudo_count}
+        if self.theta is not None:
+            fit_kwargs["theta"] = self.theta
+        return MeanFieldDCA(alignment).fit(**fit_kwargs)
 
 
 class EVcouplingsPLM(EVcouplings):
@@ -566,7 +569,7 @@ class EVcouplingsPLM(EVcouplings):
     def __init__(
         self,
         max_gap_fraction: float = 0.5,
-        theta: float = 0.8,
+        theta: float | None = None,
         lambda_h: float = 0.01,
         lambda_J: float = 0.01,
         lambda_J_times_Lq: bool = True,
@@ -586,9 +589,10 @@ class EVcouplingsPLM(EVcouplings):
             Alignment columns whose (unweighted) gap frequency strictly exceeds this
             threshold are excluded from the fitted model and from positions()
         theta
-            Sequence reweighting identity threshold; sequences with pairwise identity
+            Sequence reweighting identity threshold. Sequences with pairwise identity
             >= theta are clustered and down-weighted. Only used as a fallback when the
-            provided Sequences carry no precomputed weights
+            provided Sequences carry no precomputed weights. None falls back to the
+            plmc default (theta=0.8)
         lambda_h
             L2 regularisation strength on fields h_i
         lambda_J
@@ -625,13 +629,6 @@ class EVcouplingsPLM(EVcouplings):
         self.plmc_binary = plmc_binary
         self.cpu = cpu
 
-        if shutil.which(str(plmc_binary)) is None:
-            raise FileNotFoundError(
-                f"plmc binary not found or not executable: {plmc_binary!r}. "
-                "Pass the path to the compiled plmc executable (ex. "
-                "/path/to/plmc/bin/plmc)"
-            )
-
     def _fit(
         self,
         alignment: "Alignment",
@@ -664,23 +661,32 @@ class EVcouplingsPLM(EVcouplings):
                 with open(weight_file, "w") as f:
                     f.write("\n".join(str(w) for w in weights) + "\n")
 
-            run_plmc(
-                str(aln_file),
-                str(couplings_file),
-                param_file=str(param_file),
-                focus_seq=focus_id,
-                # None -> plmc default protein alphabet (gap included)
-                alphabet=None,
-                theta=self.theta if weights is None else None,
-                scale=self.scale_clusters,
-                ignore_gaps=self.ignore_gaps,
-                iterations=self.iterations,
-                lambda_h=self.lambda_h,
-                lambda_J=lambda_J,
-                lambda_g=self.lambda_group,
-                cpu=self.cpu,
-                binary=str(self.plmc_binary),
-                weight_file=str(weight_file) if weight_file is not None else None,
-            )
+            try:
+                run_plmc(
+                    str(aln_file),
+                    str(couplings_file),
+                    param_file=str(param_file),
+                    focus_seq=focus_id,
+                    # None -> plmc default protein alphabet (gap included)
+                    alphabet=None,
+                    theta=self.theta if weights is None else None,
+                    scale=self.scale_clusters,
+                    ignore_gaps=self.ignore_gaps,
+                    iterations=self.iterations,
+                    lambda_h=self.lambda_h,
+                    lambda_J=lambda_J,
+                    lambda_g=self.lambda_group,
+                    cpu=self.cpu,
+                    binary=str(self.plmc_binary),
+                    weight_file=str(weight_file) if weight_file is not None else None,
+                )
+            except ExternalToolError as e:
+                if isinstance(e.__cause__, OSError):
+                    raise FileNotFoundError(
+                        f"plmc binary not found or not executable: {self.plmc_binary!r}. "
+                        "Pass the path to the compiled plmc executable (ex. "
+                        "/path/to/plmc/bin/plmc)"
+                    ) from e
+                raise
 
             return CouplingsModel(str(param_file), file_format="plmc_v2")

--- a/src/evedesign/models/evcouplings.py
+++ b/src/evedesign/models/evcouplings.py
@@ -21,10 +21,16 @@ from pathlib import Path
 from typing import Any, Literal, Self, Sequence
 
 import numpy as np
+import pandas as pd
 
-from evedesign.model import BaseModel, Scorer
-from evedesign.system import System, SystemInstance
-from evedesign.sequence import REMOVE_INSERTIONS_TRANSLATION
+from evedesign.model import (
+    BaseModel,
+    Scorer,
+    MutationScorer,
+    ConditionalMutationScorer,
+    assign_scores_to_instances,
+)
+from evedesign.system import System, SystemInstance, Entity
 from evedesign.constants import GAP, MASK
 from evedesign.types import StatusCallback
 from evedesign.utils import status_done, status_start
@@ -32,14 +38,19 @@ from evedesign.utils import status_done, status_start
 try:
     from evcouplings.align.alignment import Alignment, ALPHABET_PROTEIN
     from evcouplings.couplings.mean_field import MeanFieldDCA
-    from evcouplings.couplings.model import CouplingsModel
+    from evcouplings.couplings.model import (
+        CouplingsModel,
+        _single_mutant_hamiltonians,
+        _delta_hamiltonian,
+        FULL,
+    )
     from evcouplings.couplings.tools import run_plmc
     IMPORT_AVAILABLE = True
 except ImportError:
     IMPORT_AVAILABLE = False
 
 
-class EVcouplings(BaseModel, Scorer):
+class EVcouplings(BaseModel, Scorer, MutationScorer, ConditionalMutationScorer):
     """
     Abstract base wrapper around EVcouplings/EVmutation
 
@@ -53,9 +64,7 @@ class EVcouplings(BaseModel, Scorer):
         # EVmutation
         "10.1038/nbt.3769",
         # EVcouplings
-        "10.1093/bioinformatics/bty862",
-        # plmc ? idk if there is a paper
-    ]
+        "10.1093/bioinformatics/bty862"]
 
     # core properties
     requires_target: bool = True
@@ -85,7 +94,8 @@ class EVcouplings(BaseModel, Scorer):
             threshold are excluded from the fitted model and from positions()
         theta
             Sequence reweighting identity threshold; sequences with pairwise identity
-            >= theta are clustered and down-weighted. Used by both engines.
+            >= theta are clustered and down-weighted. Only used when
+            provided Sequences carry no precomputed weights
         """
         if not self.available:
             raise ImportError(
@@ -138,23 +148,22 @@ class EVcouplings(BaseModel, Scorer):
         return True, ""
 
 
-    @staticmethod
-    def _match_states(seq: str) -> str:
-        """Strip insertion states from an aligned sequence, leaving only match-state columns"""
-        return seq.translate(REMOVE_INSERTIONS_TRANSLATION)
-
     def _build_alignment(self, target) -> tuple["Alignment", np.ndarray]:
         """
         Build an evcouplings Alignment from the system MSA and lower-case
         the high-gap columns so they are excluded from the fit
 
+        Match-state columns are obtained by converting the MSA to a3m and stripping
+        insertions; the alignment is numbered from a fixed first index of 1 (any mapping
+        back to the entity's first_index is handled by positions()/score()).
+
         Returns the (possibly modified) Alignment and the boolean mask of excluded columns
         """
-        seqs = target.sequences.seqs
         target_rep = "".join(target.rep)
         length = len(target_rep)
 
-        match_seqs = [self._match_states(s.seq) for s in seqs]
+        seqs = target.sequences.to_a3m().remove_inserts().seqs
+        match_seqs = [s.seq for s in seqs]
 
         bad = [i for i, m in enumerate(match_seqs) if len(m) != length]
         if bad:
@@ -169,10 +178,10 @@ class EVcouplings(BaseModel, Scorer):
                 "EVcouplings requires the target sequence as the first alignment record"
             )
 
-        first_index = target.first_index
+        # fixed internal numbering starting at 1
         focus_id = str(seqs[0].id_).split()[0]
         ids = (
-            [f"{focus_id}/{first_index}-{first_index + length - 1}"]
+            [f"{focus_id}/1-{length}"]
             + [str(s.id_) for s in seqs[1:]]
         )
 
@@ -201,6 +210,7 @@ class EVcouplings(BaseModel, Scorer):
         alignment: "Alignment",
         focus_id: str,
         num_model_positions: int,
+        weights: Sequence[float] | None = None,
     ) -> "CouplingsModel":
         """
         Fit the engine-specific Potts model and return the parsed CouplingsModel.
@@ -233,7 +243,10 @@ class EVcouplings(BaseModel, Scorer):
             np.array([c.isupper() and c != GAP for c in alignment[0]]).sum()
         )
 
-        self.model = self._fit(alignment, focus_id, num_model_positions)
+        # prefer precomputed sequence weights; theta is only a fallback
+        weights = target.sequences.weights
+
+        self.model = self._fit(alignment, focus_id, num_model_positions, weights)
         self._index_list = np.asarray(self.model.index_list, dtype=int)
 
         status_done(status_callback, "EVcouplings model finished fitting")
@@ -250,7 +263,8 @@ class EVcouplings(BaseModel, Scorer):
         content are not part of the fitted model and are therefore not returned
         """
         self.ready_or_raise()
-        return [(0, int(pos)) for pos in self._index_list]
+        first_index = self.system[0].first_index
+        return [(0, int(pos) - 1 + first_index) for pos in self._index_list]
 
 
     # elected to score full sequence to avoid dealing with indexing
@@ -258,7 +272,7 @@ class EVcouplings(BaseModel, Scorer):
         self,
         instances: Sequence[SystemInstance],
         status_callback: StatusCallback | None = None,
-    ) -> np.ndarray:
+    ) -> list[SystemInstance]:
         """
         Score full sequences by their statistical energy
 
@@ -269,13 +283,11 @@ class EVcouplings(BaseModel, Scorer):
         self._validate_instances(instances)
 
         if len(instances) == 0:
-            return np.empty((0,), dtype=float)
+            return []
 
         status_start(status_callback, "Scoring sequences")
 
-        first_index = self.system[0].first_index
-        # map modelled residue numbers to 0-based positions in the (fixed-length) rep
-        col_pos = self._index_list - first_index
+        col_pos = self._index_list - 1
 
         subseqs = []
         for instance in instances:
@@ -292,7 +304,205 @@ class EVcouplings(BaseModel, Scorer):
 
         status_done(status_callback, "Scoring complete")
 
-        return np.asarray(hamiltonians, dtype=float)
+        return assign_scores_to_instances(
+            instances, np.asarray(hamiltonians, dtype=float)
+        )
+
+    def _instance_background(
+        self,
+        instance: SystemInstance,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Map the entity-0 rep of an instance onto the model-internal integer background
+        over the modelled (non-excluded) positions.
+
+        Returns
+        -------
+        bg
+            Integer array of length L with the modelled-position symbols (0 for invalid)
+        subseq
+            Char array of length L with the raw modelled-position symbols (for ref labelling)
+        invalid
+            Boolean array of length L, True where the symbol is not in the model alphabet
+        """
+        model = self.model
+        col_pos = self._index_list - 1
+        subseq = np.asarray(instance[0].rep)[col_pos]
+
+        bg = np.zeros(model.L, dtype=int)
+        invalid = np.zeros(model.L, dtype=bool)
+        for i, sym in enumerate(subseq):
+            sym = str(sym)
+            if sym in model.alphabet_map:
+                bg[i] = model.alphabet_map[sym]
+            else:
+                invalid[i] = True
+
+        return bg, subseq, invalid
+
+
+    def single_mutation_scan(
+        self,
+        instance: SystemInstance,
+        entity: int | None = None,
+        positions: Sequence[int] | None = None,
+        status_callback: StatusCallback | None = None,
+    ) -> pd.DataFrame:
+        """
+        Compute all single substitutions to an instance via the model single-mutant matrix.
+
+        This wraps _single_mutant_hamiltonians kernel (same as CouplingsModel.single_mut_mat) 
+        but evaluated relative to the given instance rather than the model query seq
+
+        Scores are delta-Hamiltonians (mutant - instance)
+        """
+        self.ready_or_raise()
+        self._validate_instances([instance])
+
+        # only entity 0 is modelled by EVcouplings
+        if entity is not None and entity != 0:
+            raise ValueError("EVcouplings only models entity 0")
+
+        if positions is not None:
+            if entity is None:
+                raise ValueError(
+                    "Parameter entity must be explicitly specified if using parameter positions"
+                )
+            self.valid_positions(positions, instance, entity, raise_invalid=True)
+
+        status_start(status_callback, "Computing single mutation scan")
+
+        model = self.model
+        first_index = self.system[0].first_index
+
+        # map the instance onto the integer background over modelled positions
+        bg, subseq, invalid = self._instance_background(instance)
+
+        # full L x num_symbols delta-Hamiltonian matrix relative to this background
+        delta = _single_mutant_hamiltonians(bg, model.J_ij, model.h_i)[:, :, FULL]
+
+        if invalid.any():
+            delta = np.full_like(delta, np.nan)
+
+        # evedesign positions aligned with the model array order
+        evc_positions = self._index_list - 1 + first_index
+        pos_filter = set(positions) if positions is not None else None
+
+        # columns of delta are in model alphabet order
+        model_alphabet = list(model.alphabet)
+
+        rows = []
+        index_tuples = []
+        for i in range(model.L):
+            evc_pos = int(evc_positions[i])
+            if pos_filter is not None and evc_pos not in pos_filter:
+                continue
+            rows.append(delta[i])
+            index_tuples.append((0, evc_pos, str(subseq[i])))
+
+        df = pd.DataFrame(
+            rows,
+            columns=model_alphabet,
+            index=pd.MultiIndex.from_tuples(
+                index_tuples, names=["entity", "pos", "ref"]
+            ),
+        )
+
+        # reorder/select columns into the evedesign alphabet
+        merged_alphabet = Entity.merge_alphabet_symbols([
+            self.system[0].alphabet(
+                include_gap=self.handles_deletions,
+                include_inserts=self.handles_insertions,
+            )
+        ])
+        df = df.reindex(merged_alphabet, axis=1)
+
+        status_done(status_callback, "Single mutation scan complete")
+
+        return df
+
+
+    def score_conditional(
+        self,
+        instances: Sequence[SystemInstance],
+        entities: Sequence[int],
+        positions: Sequence[int],
+        status_callback: StatusCallback | None = None,
+    ) -> pd.DataFrame:
+        """
+        Compute conditional substitution scores P(x_i | x_\\i) for one position per instance
+
+        Conditional energy of symbol A at position i given the rest of
+        the sequence fixed is h_i[i, A] + sum_{j != i} J_ij[i, j, A, x_j]
+        """
+        self.ready_or_raise()
+
+        if not len(instances) == len(entities) == len(positions):
+            raise ValueError(
+                "Sequences for instances, entities and positions must all have same length"
+            )
+
+        self._validate_instances(instances)
+
+        # validate entity/position per instance (entity must be 0, position must be modelled)
+        for instance, entity, pos in zip(instances, entities, positions):
+            self.valid_positions(
+                positions=[pos], instance=instance, entities=[entity], raise_invalid=True
+            )
+
+        status_start(status_callback, "Computing conditional scores")
+
+        model = self.model
+        first_index = self.system[0].first_index
+        num_symbols = model.num_symbols
+
+        # evedesign position -> model array index
+        evc_positions = self._index_list - 1 + first_index
+        pos_to_mi = {int(p): i for i, p in enumerate(evc_positions)}
+
+        model_alphabet = list(model.alphabet)
+
+        rows = []
+        index_tuples = []
+        for inst_idx, (instance, entity, pos) in enumerate(zip(instances, entities, positions)):
+            bg, _, invalid = self._instance_background(instance)
+            mi = pos_to_mi[int(pos)]
+
+            bg_invalid = invalid.copy()
+            bg_invalid[mi] = False
+
+            if bg_invalid.any():
+                logits = np.full(num_symbols, np.nan)
+            else:
+                logits = np.array([
+                    _delta_hamiltonian(
+                        np.array([mi]), np.array([symbol]), bg, model.J_ij, model.h_i
+                    )[FULL]
+                    for symbol in range(num_symbols)
+                ])
+
+            rows.append(logits)
+            index_tuples.append((inst_idx, int(entity), int(pos)))
+
+        df = pd.DataFrame(
+            rows,
+            columns=model_alphabet,
+            index=pd.MultiIndex.from_tuples(
+                index_tuples, names=["instance", "entity", "pos"]
+            ),
+        )
+
+        merged_alphabet = Entity.merge_alphabet_symbols([
+            self.system[entity_idx].alphabet(
+                include_gap=self.handles_deletions,
+                include_inserts=self.handles_insertions,
+            ) for entity_idx in set(entities)
+        ])
+        df = df.reindex(merged_alphabet, axis=1)
+
+        status_done(status_callback, "Conditional scoring complete")
+
+        return df
 
 
 class EVcouplingsMeanField(EVcouplings):
@@ -329,7 +539,10 @@ class EVcouplingsMeanField(EVcouplings):
         alignment: "Alignment",
         focus_id: str,
         num_model_positions: int,
+        weights: Sequence[float] | None = None,
     ) -> "CouplingsModel":
+        # mean-field DCA does not yet support precomputed weights, so it always
+        # reweights via theta (the precomputed Sequences weights are ignored here)
         return MeanFieldDCA(alignment).fit(
             theta=self.theta, pseudo_count=self.pseudo_count
         )
@@ -344,6 +557,10 @@ class EVcouplingsPLM(EVcouplings):
     name: str = "EVcouplingsPLM"
     # plmc can be compiled w/ multi-core fitting
     supports_cpu_parallel: bool = True
+
+    @property
+    def handles_deletions(self) -> bool:
+        return not self.ignore_gaps
 
     def __init__(
         self,
@@ -369,7 +586,8 @@ class EVcouplingsPLM(EVcouplings):
             threshold are excluded from the fitted model and from positions()
         theta
             Sequence reweighting identity threshold; sequences with pairwise identity
-            >= theta are clustered and down-weighted
+            >= theta are clustered and down-weighted. Only used as a fallback when the
+            provided Sequences carry no precomputed weights
         lambda_h
             L2 regularisation strength on fields h_i
         lambda_J
@@ -410,6 +628,7 @@ class EVcouplingsPLM(EVcouplings):
         alignment: "Alignment",
         focus_id: str,
         num_model_positions: int,
+        weights: Sequence[float] | None = None,
     ) -> "CouplingsModel":
         # scale lambda_J as in the standard couplings protocol
         lambda_J = self.lambda_J
@@ -429,6 +648,13 @@ class EVcouplingsPLM(EVcouplings):
             with open(aln_file, "w") as f:
                 alignment.write(f, format="fasta")
 
+            # prefer precomputed sequence weights 
+            weight_file = None
+            if weights is not None:
+                weight_file = tmp / "weights.txt"
+                with open(weight_file, "w") as f:
+                    f.write("\n".join(str(w) for w in weights) + "\n")
+
             run_plmc(
                 str(aln_file),
                 str(couplings_file),
@@ -436,7 +662,7 @@ class EVcouplingsPLM(EVcouplings):
                 focus_seq=focus_id,
                 # None -> plmc default protein alphabet (gap included)
                 alphabet=None,
-                theta=self.theta,
+                theta=self.theta if weights is None else None,
                 scale=self.scale_clusters,
                 ignore_gaps=self.ignore_gaps,
                 iterations=self.iterations,
@@ -445,6 +671,7 @@ class EVcouplingsPLM(EVcouplings):
                 lambda_g=self.lambda_group,
                 cpu=self.cpu,
                 binary=str(self.plmc_binary),
+                weight_file=str(weight_file) if weight_file is not None else None,
             )
 
             return CouplingsModel(str(param_file), file_format="plmc_v2")

--- a/src/evedesign/sequence.py
+++ b/src/evedesign/sequence.py
@@ -5,12 +5,47 @@ from string import ascii_lowercase
 from typing import Any, Literal, Self, TextIO
 from pathlib import Path
 from collections import abc
+
+import numpy as np
+from numba import jit, prange, get_num_threads, set_num_threads
+
 from evedesign.constants import MASK, GAP
 from evedesign.types import BioPolymer, RepSequence, SequenceMetadata
-from evedesign.utils import shorten
+from evedesign.utils import shorten, str_to_np_char_view, map_array, index_map
 
 
 REMOVE_INSERTIONS_TRANSLATION = str.maketrans("", "", ascii_lowercase + ".")
+
+ALPHABETS: dict[str, str] = {
+    "protein": GAP + "ACDEFGHIKLMNPQRSTVWY",
+    "dna": GAP + "ACGT",
+    "rna": GAP + "ACGU",
+}
+
+
+@jit(nopython=True, parallel=True)
+def _num_cluster_members(matrix, identity_threshold, exclude_value):
+    """
+    EVcouplings function for calculating sequence weights
+    """
+    N, L = matrix.shape
+    num_neighbors = np.zeros((N, ))
+    L_seq = np.sum(matrix != exclude_value, axis=1)
+
+    for i in prange(N):
+        num_neighbors_i = 1 
+        for j in range(N):
+            if i == j:
+                continue
+            matches = 0
+            for k in range(L):
+                if matrix[i, k] == matrix[j, k] and matrix[i, k] != exclude_value:
+                    matches += 1
+            if matches / L_seq[i] >= identity_threshold:
+                num_neighbors_i += 1
+        num_neighbors[i] = num_neighbors_i
+
+    return num_neighbors
 
 
 class Sequence:
@@ -209,7 +244,52 @@ class Sequences:
             aligned=True,
             weights=self.weights,
             format=self.format_
-        )        
+        )
+
+    def compute_weights(
+        self,
+        theta: float = 0.8,
+        method: Literal["nogaps", "withgaps"] = "withgaps",
+        cpu: int | None = None,
+    ) -> Self:
+        """
+        Compute per-sequence weights and assign them to self.weights
+
+        Parameters
+        ----------
+        theta
+            Sequence identity threshold for clustering
+        method
+            withgaps includes gaps in the identity calculation (default
+            EVcouplings), nogaps excludes them
+        cpu
+            Number of numba threads (None uses all)
+
+        Returns
+        -------
+        Self (with self.weights)
+        """
+        match_seqs = [s.seq for s in self.to_a3m().remove_inserts().seqs]
+
+        alphabet = ALPHABETS.get(self.type_, ALPHABETS["protein"])
+        mapping = index_map(list(alphabet), default_option=GAP)
+        matrix = map_array(str_to_np_char_view(match_seqs), mapping)
+
+        exclude_value = mapping[GAP] if method == "nogaps" else -1
+
+        threads_before = None
+        if cpu is not None:
+            threads_before = get_num_threads()
+            set_num_threads(cpu)
+        try:
+            num_cluster_members = _num_cluster_members(matrix, theta, exclude_value)
+        finally:
+            if threads_before is not None:
+                set_num_threads(threads_before)
+
+        self.weights = [float(w) for w in 1.0 / num_cluster_members]
+
+        return self
 
     def serialize(self) -> dict[str, Any]:
         """

--- a/src/evedesign/sequence.py
+++ b/src/evedesign/sequence.py
@@ -9,24 +9,51 @@ from collections import abc
 import numpy as np
 from numba import jit, prange, get_num_threads, set_num_threads
 
-from evedesign.constants import MASK, GAP
+from evedesign.constants import (
+    MASK,
+    GAP,
+    VALID_AA_OR_GAP_SORTED,
+    VALID_DNA_OR_GAP_SORTED,
+    VALID_RNA_OR_GAP_SORTED,
+)
 from evedesign.types import BioPolymer, RepSequence, SequenceMetadata
 from evedesign.utils import shorten, str_to_np_char_view, map_array, index_map
 
 
 REMOVE_INSERTIONS_TRANSLATION = str.maketrans("", "", ascii_lowercase + ".")
 
-ALPHABETS: dict[str, str] = {
-    "protein": GAP + "ACDEFGHIKLMNPQRSTVWY",
-    "dna": GAP + "ACGT",
-    "rna": GAP + "ACGU",
+ALPHABETS_OR_GAP_SORTED: dict[str, list[str]] = {
+    "protein": VALID_AA_OR_GAP_SORTED,
+    "dna": VALID_DNA_OR_GAP_SORTED,
+    "rna": VALID_RNA_OR_GAP_SORTED,
 }
 
 
 @jit(nopython=True, parallel=True)
 def _num_cluster_members(matrix, identity_threshold, exclude_value):
     """
-    EVcouplings function for calculating sequence weights
+    Calculate number of sequences in alignment
+    within given identity_threshold of each other
+
+    Parameters
+    ----------
+    matrix : np.array
+        N x L matrix containing N sequences of length L.
+        Matrix must be mapped to range(0, num_symbols) using
+        map_matrix function
+    identity_threshold : float
+        Sequences with at least this pairwise identity will be
+        grouped in the same cluster.
+    exclude_value : int
+        Value >= 0 in matrix that will be excluded from identity calculation, e.g. gap or lowercase character.
+        Set to -1 to enable legacy behaviour which includes gaps in identity calculation.
+
+    Returns
+    -------
+    np.array
+        Vector of length N containing number of cluster
+        members for each sequence (inverse of sequence
+        weight)
     """
     N, L = matrix.shape
     num_neighbors = np.zeros((N, ))
@@ -249,33 +276,38 @@ class Sequences:
     def compute_weights(
         self,
         theta: float = 0.8,
-        method: Literal["nogaps", "withgaps"] = "withgaps",
+        method: Literal["theta_nogaps", "theta_withgaps"] = "theta_nogaps",
         cpu: int | None = None,
     ) -> Self:
         """
-        Compute per-sequence weights and assign them to self.weights
+        Compute per-sequence weights and return a copy with the weights set
+
+        Does not mutate the current object. The returned Sequences shares the same
+        underlying Sequence objects with weights replaced
 
         Parameters
         ----------
         theta
             Sequence identity threshold for clustering
         method
-            withgaps includes gaps in the identity calculation (default
-            EVcouplings), nogaps excludes them
+            theta_nogaps excludes gaps from identity calculation,
+            theta_withgaps includes them 
         cpu
             Number of numba threads (None uses all)
 
         Returns
         -------
-        Self (with self.weights)
+        A copy of this Sequences object with weights set
         """
         match_seqs = [s.seq for s in self.to_a3m().remove_inserts().seqs]
 
-        alphabet = ALPHABETS.get(self.type_, ALPHABETS["protein"])
+        alphabet = ALPHABETS_OR_GAP_SORTED.get(
+            self.type_, ALPHABETS_OR_GAP_SORTED["protein"]
+        )
         mapping = index_map(list(alphabet), default_option=GAP)
         matrix = map_array(str_to_np_char_view(match_seqs), mapping)
 
-        exclude_value = mapping[GAP] if method == "nogaps" else -1
+        exclude_value = mapping[GAP] if method == "theta_nogaps" else -1
 
         threads_before = None
         if cpu is not None:
@@ -287,9 +319,15 @@ class Sequences:
             if threads_before is not None:
                 set_num_threads(threads_before)
 
-        self.weights = [float(w) for w in 1.0 / num_cluster_members]
+        weights = [float(w) for w in 1.0 / num_cluster_members]
 
-        return self
+        return type(self)(
+            seqs=self.seqs,
+            aligned=self.aligned,
+            type=self.type_,
+            weights=weights,
+            format=self.format_,
+        )
 
     def serialize(self) -> dict[str, Any]:
         """


### PR DESCRIPTION
evcouplings.py in models/

Points for discussion:

- tried to avoid using the protocols to circumvent writing a bunch of permanent files, but run_plmc still requires a bunch of temp files + writing alignments to file for reading is kind of annoying. May be impossible to avoid?
- Ton of init params to try and capture basically everything in the couplings pipeline stage in cfg file
- Name: evcouplings vs evmutation
- Additional fxns in class (ex. MutationScorer, single mutation scan, etc.) I tried to keep it light initially since I think it will be worth debating what is here currently before adding functionalities
- model loading (in build()) was also kind of annoying, might be a better way than having to settle for these intermediate temp files etc