### PR TITLE
Adding the gpytorch supervised helper class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ evmutation2 = ["torch", "evmutation2"]
 esm2 = ["torch", "transformers"]
 mpnn = ["torch", "prody"]
 umap = ["umap-learn"]
+gpytorch = ["torch", "gpytorch"]
 
 [project.urls]
 Documentation = "https://github.com/evedesignbio/evedesign#readme"

--- a/src/evedesign/model.py
+++ b/src/evedesign/model.py
@@ -317,11 +317,13 @@ class Scorer(_Core):
 def assign_scores_to_instances(
     instances: Sequence[SystemInstance],
     scores: Sequence[float],
+    uncertainties: Sequence[float] | None = None,
 ):
     """
     Helper function to assign a sequence of scores to a sequence of instances, creating
     a shallow copy of each instance and its entities. All sequences must have the same length.
-    The confidence attribute will be set to None.
+
+    The confidence attribute will be set to the corresponding value in uncertainties if provided
 
     Parameters
     ----------
@@ -329,15 +331,24 @@ def assign_scores_to_instances(
         Sequence of instances to which scores will be assigned
     scores
         Sequence of scores to assign, must have same length as instances
+    uncertainties
+        Optional sequence of uncertainty values to assign to the confidence attribute of each instance.
+        If None (default), the confidence attribute is set to None. If provided, must have same length
+        as instances.
 
     Returns
     -------
     scored_instances
-        Sequence of instances with assigned scores
+        Sequence of instances with assigned scores (and confidences if applicable)
     """
     if len(scores) != len(instances):
         raise ValueError(
             "Length of scores does not match length of instances"
+        )
+
+    if uncertainties is not None and len(uncertainties) != len(instances):
+        raise ValueError(
+            "Length of uncertainties does not match length of instances"
         )
 
     # create shallow copy of instances
@@ -345,9 +356,9 @@ def assign_scores_to_instances(
         inst.copy() for inst in instances
     ]
 
-    for inst, score in zip(instances_scored, scores):
+    for idx, (inst, score) in enumerate(zip(instances_scored, scores)):
         inst.score = score
-        inst.confidence = None
+        inst.confidence = uncertainties[idx] if uncertainties is not None else None
 
     return instances_scored
 

--- a/src/evedesign/model.py
+++ b/src/evedesign/model.py
@@ -317,13 +317,13 @@ class Scorer(_Core):
 def assign_scores_to_instances(
     instances: Sequence[SystemInstance],
     scores: Sequence[float],
-    uncertainties: Sequence[float] | None = None,
+    confidences: Sequence[float] | None = None,
 ):
     """
     Helper function to assign a sequence of scores to a sequence of instances, creating
     a shallow copy of each instance and its entities. All sequences must have the same length.
 
-    The confidence attribute will be set to the corresponding value in uncertainties if provided
+    The confidence attribute will be set to the corresponding value in confidences if provided
 
     Parameters
     ----------
@@ -331,8 +331,8 @@ def assign_scores_to_instances(
         Sequence of instances to which scores will be assigned
     scores
         Sequence of scores to assign, must have same length as instances
-    uncertainties
-        Optional sequence of uncertainty values to assign to the confidence attribute of each instance.
+    confidences
+        Optional sequence of values to assign to the confidence attribute of each instance.
         If None (default), the confidence attribute is set to None. If provided, must have same length
         as instances.
 
@@ -346,9 +346,9 @@ def assign_scores_to_instances(
             "Length of scores does not match length of instances"
         )
 
-    if uncertainties is not None and len(uncertainties) != len(instances):
+    if confidences is not None and len(confidences) != len(instances):
         raise ValueError(
-            "Length of uncertainties does not match length of instances"
+            "Length of confidences does not match length of instances"
         )
 
     # create shallow copy of instances
@@ -358,7 +358,7 @@ def assign_scores_to_instances(
 
     for idx, (inst, score) in enumerate(zip(instances_scored, scores)):
         inst.score = score
-        inst.confidence = uncertainties[idx] if uncertainties is not None else None
+        inst.confidence = confidences[idx] if confidences is not None else None
 
     return instances_scored
 

--- a/src/evedesign/models/supervised.py
+++ b/src/evedesign/models/supervised.py
@@ -4,7 +4,7 @@ Supervised regression models trained on top of embeddings and/or scores from zer
 import copy
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
-from typing import Any, Callable, Sequence, Literal
+from typing import Any, Sequence, Literal
 import numpy as np
 from sklearn.base import ClassifierMixin
 from sklearn.exceptions import NotFittedError
@@ -667,29 +667,24 @@ class SklearnPredictorOnEmbeddingsScores(SupervisedPredictorOnEmbeddingsScores):
 
 
 if GPYTORCH_AVAILABLE:
-    class _DefaultExactGP(gpytorch.models.ExactGP):
+    class _ExactGPModel(gpytorch.models.ExactGP):
         """
-        Default ExactGP: constant mean + RBF kernel with output scaling, paired with the supplied likelihood.
-        Used by GpytorchModel when no gp_model_cls is given
+        Generic exact GP that wires a supplied mean and covariance module into the standard
+        forward, MultivariateNormal(mean(x), covar(x)), paired with the supplied likelihood.
+
+        This covers standard exact GP regression for any combination of gpytorch mean/kernel/likelihood
+        modules, which can all be instantiated upfront and passed to GpytorchModel. Models requiring a
+        custom forward (e.g. deep kernels with neural feature extractors, multitask GPs) are not handled.
         """
-        def __init__(self, train_x, train_y, likelihood):
+        def __init__(self, train_x, train_y, likelihood, mean_module, covar_module):
             super().__init__(train_x, train_y, likelihood)
-            self.mean_module = gpytorch.means.ConstantMean()
-            self.covar_module = gpytorch.kernels.ScaleKernel(
-                gpytorch.kernels.RBFKernel()
-            )
+            self.mean_module = mean_module
+            self.covar_module = covar_module
 
         def forward(self, x):
             mean_x = self.mean_module(x)
             covar_x = self.covar_module(x)
             return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
-
-
-def _build_default_gp(train_x, train_y, likelihood):
-    """
-    Build the default ExactGP (constant mean + scaled RBF kernel) from the training tensors and likelihood
-    """
-    return _DefaultExactGP(train_x, train_y, likelihood)
 
 
 class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
@@ -710,15 +705,14 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
 
     def __init__(
         self,
-        gp_model_cls: type | None = None,
-        gp_model_kwargs: dict[str, Any] | None = None,
+        mean_module: Any | None = None,
+        covar_module: Any | None = None,
         likelihood: Any | None = None,
         num_iters: int = 100,
         learning_rate: float = 0.1,
-        optimizer_cls: Any | None = None,
+        optimizer: str = "Adam",
         optimizer_kwargs: dict[str, Any] | None = None,
-        mll_cls: Any | None = None,
-        train_loop: Callable[[Any, Any, Any, Any, Any], None] | None = None,
+        mll: str = "ExactMarginalLogLikelihood",
         standardize_targets: bool = True,
         device: DeviceType = "cpu",
         embedder: Transformer | None = None,
@@ -733,39 +727,36 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
         """
         Train an exact Gaussian process regression model on top of molecular model embeddings/scores.
 
+        The GP is specified by supplying instantiated gpytorch mean, covariance, and likelihood
+        modules. These are fed to a standard exact-GP forward (MultivariateNormal(mean(x), covar(x)))
+        and copied for each fit so repeated fits start from the same initial hyperparameters
+
         Parameters
         ----------
-        gp_model_cls
-            A gpytorch.models.ExactGP subclass to use as the GP model, constructed internally for each fit as
-            gp_model_cls(train_x, train_y, likelihood, **gp_model_kwargs). (unlike a sklearn estimator, an
-            ExactGP cannot be instantiated before the training tensors are available) this also keeps the 
-            specification serializable
-        gp_model_kwargs
-            Extra keyword arguments forwarded to gp_model_cls after (train_x, train_y, likelihood). Ignored if
-            gp_model_cls is None
+        mean_module
+            A fully-instantiated gpytorch mean module (gpytorch.means.Mean). If None, a ConstantMean is used
+        covar_module
+            A fully-instantiated gpytorch kernel module (gpytorch.kernels.Kernel). If None, a scaled RBF kernel
+            ScaleKernel(RBFKernel()) is used
         likelihood
-            A fully-instantiated gpytorch Likelihood instance to use. It is copied for each fit so repeated fits
-            start from the same initial hyperparameters. If None, a GaussianLikelihood is used
+            A fully-instantiated gpytorch Likelihood instance to use. If None, a GaussianLikelihood is used
         num_iters
-            Number of optimizer steps for the default training loop (ignored if train_loop is provided)
+            Number of optimizer steps for the training loop
         learning_rate
-            Learning rate for the default optimizer (ignored if train_loop is provided)
-        optimizer_cls
-            torch optimizer class to use for the default training loop, constructed as
-            optimizer_cls(model.parameters(), lr=learning_rate, **optimizer_kwargs). If None, torch.optim.Adam
+            Learning rate for the optimizer
+        optimizer
+            Name of a torch.optim optimizer class to use, constructed as
+            getattr(torch.optim, optimizer)(model.parameters(), lr=learning_rate, **optimizer_kwargs)
         optimizer_kwargs
             Extra keyword arguments forwarded to the optimizer constructor
-        mll_cls
-            Marginal log-likelihood class, constructed as mll_cls(likelihood, model) and maximized during
-            training. If None, gpytorch.mlls.ExactMarginalLogLikelihood
-        train_loop
-            Optional callable (model, likelihood, train_x, train_y, mll) -> None that replaces the default
-            optimization loop, for complete control over training (schedulers, early stopping, etc.)
+        mll
+            Name of a gpytorch.mlls marginal log-likelihood class, constructed as
+            getattr(gpytorch.mlls, mll)(likelihood, model) and maximized during training
         standardize_targets
             If True, standardize y to zero mean / unit variance before fitting and invert the transform on
             predictions
         device
-            Device on which to place tensors and run inference ("cpu", "cuda" or "mps")
+            Device on which to run inference ("cpu", "cuda" or "mps")
         embedder, scorer, use_embeddings, use_scores, override_models_for_training, target_name, pooling, batch_size
             See SupervisedPredictorOnEmbeddingsScores
         """
@@ -775,17 +766,31 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
                 "Install with the optional dependency pip install evedesign[gpytorch]"
             )
 
-        # validate model/likelihood specs (safe to reference gpytorch after availability check above)
-        if gp_model_cls is not None and not (
-            isinstance(gp_model_cls, type) and issubclass(gp_model_cls, gpytorch.models.ExactGP)
-        ):
+        # validate module specs (safe to reference gpytorch after availability check above)
+        if mean_module is not None and not isinstance(mean_module, gpytorch.means.Mean):
             raise ValueError(
-                "gp_model_cls must be a subclass of gpytorch.models.ExactGP (or None for the default GP)"
+                "mean_module must be a gpytorch Mean instance, or None for a ConstantMean"
+            )
+
+        if covar_module is not None and not isinstance(covar_module, gpytorch.kernels.Kernel):
+            raise ValueError(
+                "covar_module must be a gpytorch Kernel instance, or None for a scaled RBF kernel"
             )
 
         if likelihood is not None and not isinstance(likelihood, gpytorch.likelihoods.Likelihood):
             raise ValueError(
                 "likelihood must be a gpytorch Likelihood instance, or None for a GaussianLikelihood"
+            )
+
+        # validate optimizer/mll selectors upfront so misconfiguration fails fast
+        if not hasattr(torch.optim, optimizer):
+            raise ValueError(
+                f"Unknown optimizer '{optimizer}', must be a class in torch.optim (e.g. 'Adam')"
+            )
+
+        if not hasattr(gpytorch.mlls, mll):
+            raise ValueError(
+                f"Unknown mll '{mll}', must be a class in gpytorch.mlls (e.g. 'ExactMarginalLogLikelihood')"
             )
 
         super().__init__(
@@ -800,15 +805,14 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
             is_classifier=False,
         )
 
-        self.gp_model_cls = gp_model_cls
-        self.gp_model_kwargs = gp_model_kwargs if gp_model_kwargs is not None else {}
+        self.mean_spec = mean_module
+        self.covar_spec = covar_module
         self.likelihood_spec = likelihood
         self.num_iters = num_iters
         self.learning_rate = learning_rate
-        self.optimizer_cls = optimizer_cls
+        self.optimizer = optimizer
         self.optimizer_kwargs = optimizer_kwargs if optimizer_kwargs is not None else {}
-        self.mll_cls = mll_cls
-        self.train_loop = train_loop
+        self.mll = mll
         self.standardize_targets = standardize_targets
         self.device = device
 
@@ -822,19 +826,27 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
     def ready(self) -> bool:
         return self.system is not None and self._model is not None and self._likelihood is not None
 
+    def _make_mean(self):
+        # copy the supplied module (or build a default) so each fit starts from the same initial hyperparameters
+        if self.mean_spec is None:
+            return gpytorch.means.ConstantMean()
+        return copy.deepcopy(self.mean_spec)
+
+    def _make_covar(self):
+        if self.covar_spec is None:
+            return gpytorch.kernels.ScaleKernel(gpytorch.kernels.RBFKernel())
+        return copy.deepcopy(self.covar_spec)
+
     def _make_likelihood(self):
-        spec = self.likelihood_spec
-        if spec is None:
+        if self.likelihood_spec is None:
             return gpytorch.likelihoods.GaussianLikelihood()
-        # copy the supplied instance so each fit starts from the same initial hyperparameters
-        return copy.deepcopy(spec)
+        return copy.deepcopy(self.likelihood_spec)
 
     def _build_gp(self, train_x, train_y, likelihood):
-        # construct a GP model from training tensors
-        # I think pre-constructing outside of GpytorchModel might not make sense?
-        if self.gp_model_cls is None:
-            return _build_default_gp(train_x, train_y, likelihood)
-        return self.gp_model_cls(train_x, train_y, likelihood, **self.gp_model_kwargs)
+        # construct a GP model from the training tensors, wiring in fresh mean/covariance modules
+        return _ExactGPModel(
+            train_x, train_y, likelihood, self._make_mean(), self._make_covar()
+        )
 
     def _release_cache(self) -> None:
         if self.device == "cuda":
@@ -845,21 +857,23 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
     @contextmanager
     def _model_on_device(self):
         """
-        Move the fitted GP model and likelihood onto self.device for the 
-        duration of the context, then move them back to CPU on exit
+        Yield the fitted GP model and likelihood on self.device for the duration of the context.
+
         """
+        if self.device == "cpu" or self._model is None or self._likelihood is None:
+            # nothing to move
+            yield self._model, self._likelihood
+            return
+
         device = torch.device(self.device)
+        # deepcopy before moving so the canonical CPU state on the instance is never mutated
+        model = copy.deepcopy(self._model).to(device)
+        likelihood = copy.deepcopy(self._likelihood).to(device)
         try:
-            if self._model is not None:
-                self._model = self._model.to(device)
-            if self._likelihood is not None:
-                self._likelihood = self._likelihood.to(device)
-            yield
+            yield model, likelihood
         finally:
-            if self._model is not None:
-                self._model = self._model.to("cpu")
-            if self._likelihood is not None:
-                self._likelihood = self._likelihood.to("cpu")
+            # release the device copies and clear the device cache
+            del model, likelihood
             self._release_cache()
 
     def _to_tensor(self, array) -> "torch.Tensor":
@@ -887,37 +901,33 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
 
         # build fresh likelihood and model on the target device (train_x/train_y already on device)
         device = torch.device(self.device)
-        self._likelihood = self._make_likelihood().to(device)
-        self._model = self._build_gp(train_x, train_y, self._likelihood).to(device)
+        likelihood = self._make_likelihood().to(device)
+        model = self._build_gp(train_x, train_y, likelihood).to(device)
 
         # marginal log-likelihood to maximize during training
-        mll_cls = self.mll_cls if self.mll_cls is not None else gpytorch.mlls.ExactMarginalLogLikelihood
-        mll = mll_cls(self._likelihood, self._model)
+        mll_cls = getattr(gpytorch.mlls, self.mll)
+        mll = mll_cls(likelihood, model)
 
-        self._model.train()
-        self._likelihood.train()
+        model.train()
+        likelihood.train()
 
-        if self.train_loop is not None:
-            # hand full control of optimization to the user-supplied loop
-            self.train_loop(self._model, self._likelihood, train_x, train_y, mll)
-        else:
-            optimizer_cls = self.optimizer_cls if self.optimizer_cls is not None else torch.optim.Adam
-            optimizer = optimizer_cls(
-                self._model.parameters(), lr=self.learning_rate, **self.optimizer_kwargs
-            )
-            for _ in range(self.num_iters):
-                optimizer.zero_grad()
-                output = self._model(train_x)
-                loss = -mll(output, train_y)
-                loss.backward()
-                optimizer.step()
+        optimizer_cls = getattr(torch.optim, self.optimizer)
+        optimizer = optimizer_cls(
+            model.parameters(), lr=self.learning_rate, **self.optimizer_kwargs
+        )
+        for _ in range(self.num_iters):
+            optimizer.zero_grad()
+            output = model(train_x)
+            loss = -mll(output, train_y)
+            loss.backward()
+            optimizer.step()
 
-        self._model.eval()
-        self._likelihood.eval()
+        model.eval()
+        likelihood.eval()
 
         # keep fitted state on CPU so the model is serializable
-        self._model = self._model.to("cpu")
-        self._likelihood = self._likelihood.to("cpu")
+        self._model = model.to("cpu")
+        self._likelihood = likelihood.to("cpu")
         self._release_cache()
 
     def _posterior(
@@ -928,15 +938,15 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
         Compute posterior predictive mean and standard deviation (on the original target scale)
         for pre-transformed instances using the fitted GP.
         """
-        with torch.no_grad(), gpytorch.settings.fast_pred_var(), self._model_on_device():
-            # model/likelihood are on self.device inside this context; build test tensor on the same device
+        with torch.no_grad(), gpytorch.settings.fast_pred_var(), self._model_on_device() as (model, likelihood):
+            # model/likelihood are on self.device inside this context
             test_x = self._to_tensor(instances_transformed)
 
-            self._model.eval()
-            self._likelihood.eval()
+            model.eval()
+            likelihood.eval()
 
-            # pass through likelihood to obtain the predictive distribution
-            posterior = self._likelihood(self._model(test_x))
+            # pass through likelihood to obtain distribution
+            posterior = likelihood(model(test_x))
             mean = posterior.mean.detach().cpu().numpy().astype(float)
             std = posterior.stddev.detach().cpu().numpy().astype(float)
 
@@ -968,4 +978,5 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
 
         mean, std = self._posterior(x_pred)
 
-        return assign_scores_to_instances(instances, mean, uncertainties=std)
+        # store the posterior predictive stddev under the confidence attribute
+        return assign_scores_to_instances(instances, mean, confidences=std)

--- a/src/evedesign/models/supervised.py
+++ b/src/evedesign/models/supervised.py
@@ -1,7 +1,9 @@
 """
 Supervised regression models trained on top of embeddings and/or scores from zero-shot models
 """
+import copy
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from typing import Any, Callable, Sequence, Literal
 import numpy as np
 from sklearn.base import ClassifierMixin
@@ -664,12 +666,12 @@ class SklearnPredictorOnEmbeddingsScores(SupervisedPredictorOnEmbeddingsScores):
             ).astype(float)
 
 
-def _build_default_gp(train_x, train_y, likelihood):
-    """
-    Default ExactGP: constant mean + RBF kernel with output scaling,
-    paired w/ supplied likelihood. Used by GpytorchModel when no gp_factory is given
-    """
+if GPYTORCH_AVAILABLE:
     class _DefaultExactGP(gpytorch.models.ExactGP):
+        """
+        Default ExactGP: constant mean + RBF kernel with output scaling, paired with the supplied likelihood.
+        Used by GpytorchModel when no gp_model_cls is given
+        """
         def __init__(self, train_x, train_y, likelihood):
             super().__init__(train_x, train_y, likelihood)
             self.mean_module = gpytorch.means.ConstantMean()
@@ -682,6 +684,11 @@ def _build_default_gp(train_x, train_y, likelihood):
             covar_x = self.covar_module(x)
             return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
 
+
+def _build_default_gp(train_x, train_y, likelihood):
+    """
+    Build the default ExactGP (constant mean + scaled RBF kernel) from the training tensors and likelihood
+    """
     return _DefaultExactGP(train_x, train_y, likelihood)
 
 
@@ -689,8 +696,8 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
     """
     Supervised Gaussian process regression on pooled molecular embeddings/scores, backed by gpytorch.
 
-    By passing a gp_factory you can use essentially any exact GP gpytorch supports (arbitrary mean modules, 
-    kernel compositions, multi-task structure, custom forward passes), and train_loop can replace optimization.
+    The fitted model and likelihood are kept on CPU outside of inference (see _model_on_device) so the model
+    stays serializable
     """
     available = GPYTORCH_AVAILABLE
     name: str = "Gaussian process predictor on sequence embeddings/scores"
@@ -703,8 +710,9 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
 
     def __init__(
         self,
-        gp_factory: Callable[[Any, Any, Any], Any] | None = None,
-        likelihood: Any | Callable[[], Any] | None = None,
+        gp_model_cls: type | None = None,
+        gp_model_kwargs: dict[str, Any] | None = None,
+        likelihood: Any | None = None,
         num_iters: int = 100,
         learning_rate: float = 0.1,
         optimizer_cls: Any | None = None,
@@ -727,12 +735,17 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
 
         Parameters
         ----------
-        gp_factory
-            Callable ((train_x, train_y, likelihood) -> gpytorch.models.ExactGP) that builds the GP model
-            from the training tensors and likelihood. If None, a default constant-mean + scaled-RBF ExactGP is used.
-            Hyperparameters are re-initialized for each cross-validation split
+        gp_model_cls
+            A gpytorch.models.ExactGP subclass to use as the GP model, constructed internally for each fit as
+            gp_model_cls(train_x, train_y, likelihood, **gp_model_kwargs). (unlike a sklearn estimator, an
+            ExactGP cannot be instantiated before the training tensors are available) this also keeps the 
+            specification serializable
+        gp_model_kwargs
+            Extra keyword arguments forwarded to gp_model_cls after (train_x, train_y, likelihood). Ignored if
+            gp_model_cls is None
         likelihood
-            gpytorch likelihood to use. If None, a GaussianLikelihood is used
+            A fully-instantiated gpytorch Likelihood instance to use. It is copied for each fit so repeated fits
+            start from the same initial hyperparameters. If None, a GaussianLikelihood is used
         num_iters
             Number of optimizer steps for the default training loop (ignored if train_loop is provided)
         learning_rate
@@ -762,6 +775,19 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
                 "Install with the optional dependency pip install evedesign[gpytorch]"
             )
 
+        # validate model/likelihood specs (safe to reference gpytorch after availability check above)
+        if gp_model_cls is not None and not (
+            isinstance(gp_model_cls, type) and issubclass(gp_model_cls, gpytorch.models.ExactGP)
+        ):
+            raise ValueError(
+                "gp_model_cls must be a subclass of gpytorch.models.ExactGP (or None for the default GP)"
+            )
+
+        if likelihood is not None and not isinstance(likelihood, gpytorch.likelihoods.Likelihood):
+            raise ValueError(
+                "likelihood must be a gpytorch Likelihood instance, or None for a GaussianLikelihood"
+            )
+
         super().__init__(
             embedder=embedder,
             scorer=scorer,
@@ -774,7 +800,8 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
             is_classifier=False,
         )
 
-        self.gp_factory = gp_factory
+        self.gp_model_cls = gp_model_cls
+        self.gp_model_kwargs = gp_model_kwargs if gp_model_kwargs is not None else {}
         self.likelihood_spec = likelihood
         self.num_iters = num_iters
         self.learning_rate = learning_rate
@@ -795,28 +822,45 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
     def ready(self) -> bool:
         return self.system is not None and self._model is not None and self._likelihood is not None
 
-    @property
-    def gp_model(self):
-        """Fitted gpytorch ExactGP model (None until build() has been called)"""
-        return self._model
-
-    @property
-    def gp_likelihood(self):
-        """Fitted gpytorch likelihood (None until build() has been called)"""
-        return self._likelihood
-
     def _make_likelihood(self):
         spec = self.likelihood_spec
         if spec is None:
             return gpytorch.likelihoods.GaussianLikelihood()
-        # an existing likelihood instance is reused as-is, a class/callable is instantiated for a fresh one
-        if isinstance(spec, gpytorch.likelihoods.Likelihood):
-            return spec
-        if callable(spec):
-            return spec()
-        raise ValueError(
-            "likelihood must be a gpytorch Likelihood instance, a callable/class returning one, or None"
-        )
+        # copy the supplied instance so each fit starts from the same initial hyperparameters
+        return copy.deepcopy(spec)
+
+    def _build_gp(self, train_x, train_y, likelihood):
+        # construct a GP model from training tensors
+        # I think pre-constructing outside of GpytorchModel might not make sense?
+        if self.gp_model_cls is None:
+            return _build_default_gp(train_x, train_y, likelihood)
+        return self.gp_model_cls(train_x, train_y, likelihood, **self.gp_model_kwargs)
+
+    def _release_cache(self) -> None:
+        if self.device == "cuda":
+            torch.cuda.empty_cache()
+        elif self.device == "mps":
+            torch.mps.empty_cache()
+
+    @contextmanager
+    def _model_on_device(self):
+        """
+        Move the fitted GP model and likelihood onto self.device for the 
+        duration of the context, then move them back to CPU on exit
+        """
+        device = torch.device(self.device)
+        try:
+            if self._model is not None:
+                self._model = self._model.to(device)
+            if self._likelihood is not None:
+                self._likelihood = self._likelihood.to(device)
+            yield
+        finally:
+            if self._model is not None:
+                self._model = self._model.to("cpu")
+            if self._likelihood is not None:
+                self._likelihood = self._likelihood.to("cpu")
+            self._release_cache()
 
     def _to_tensor(self, array) -> "torch.Tensor":
         return torch.as_tensor(
@@ -841,15 +885,10 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
 
         train_y = self._to_tensor((y - self._y_mean) / self._y_std)
 
-        # build likelihood and model, move to device
+        # build fresh likelihood and model on the target device (train_x/train_y already on device)
         device = torch.device(self.device)
         self._likelihood = self._make_likelihood().to(device)
-
-        if self.gp_factory is not None:
-            self._model = self.gp_factory(train_x, train_y, self._likelihood)
-        else:
-            self._model = _build_default_gp(train_x, train_y, self._likelihood)
-        self._model = self._model.to(device)
+        self._model = self._build_gp(train_x, train_y, self._likelihood).to(device)
 
         # marginal log-likelihood to maximize during training
         mll_cls = self.mll_cls if self.mll_cls is not None else gpytorch.mlls.ExactMarginalLogLikelihood
@@ -876,6 +915,11 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
         self._model.eval()
         self._likelihood.eval()
 
+        # keep fitted state on CPU so the model is serializable
+        self._model = self._model.to("cpu")
+        self._likelihood = self._likelihood.to("cpu")
+        self._release_cache()
+
     def _posterior(
         self,
         instances_transformed,
@@ -884,12 +928,13 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
         Compute posterior predictive mean and standard deviation (on the original target scale)
         for pre-transformed instances using the fitted GP.
         """
-        test_x = self._to_tensor(instances_transformed)
+        with torch.no_grad(), gpytorch.settings.fast_pred_var(), self._model_on_device():
+            # model/likelihood are on self.device inside this context; build test tensor on the same device
+            test_x = self._to_tensor(instances_transformed)
 
-        self._model.eval()
-        self._likelihood.eval()
+            self._model.eval()
+            self._likelihood.eval()
 
-        with torch.no_grad(), gpytorch.settings.fast_pred_var():
             # pass through likelihood to obtain the predictive distribution
             posterior = self._likelihood(self._model(test_x))
             mean = posterior.mean.detach().cpu().numpy().astype(float)
@@ -901,39 +946,26 @@ class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
 
         return mean, std
 
+    # this doesn't actually get used, but just leaving this here for now
     def _score(
         self,
         instances_transformed,
     ) -> np.ndarray[tuple[int], np.dtype[float]]:
-        # framework score is the posterior predictive mean
         mean, _ = self._posterior(instances_transformed)
         return mean
 
-    def predict_with_uncertainty(
+    # override base score() to attach the posterior predictive standard deviation
+    def score(
         self,
         instances: Sequence[SystemInstance],
         status_callback: StatusCallback | None = None
-    ) -> tuple[np.ndarray[tuple[int], np.dtype[float]], np.ndarray[tuple[int], np.dtype[float]]]:
-        """
-        Predict posterior mean and standard deviation for a batch of instances. This is the GP-specific counterpart to score()
-        that will return the uncertainty componenet
-
-        Parameters
-        ----------
-        instances
-            Designs to predict
-        status_callback
-            Callback function to track computation status
-
-        Returns
-        -------
-        tuple of (mean, std)
-            Posterior predictive mean and standard deviation on the original target scale
-        """
+    ) -> list[SystemInstance]:
         self.ready_or_raise()
 
         x_pred = self._transform_and_validate_instances(
             instances, override_models=False, status_callback=status_callback
         )
 
-        return self._posterior(x_pred)
+        mean, std = self._posterior(x_pred)
+
+        return assign_scores_to_instances(instances, mean, uncertainties=std)

--- a/src/evedesign/models/supervised.py
+++ b/src/evedesign/models/supervised.py
@@ -2,7 +2,7 @@
 Supervised regression models trained on top of embeddings and/or scores from zero-shot models
 """
 from abc import ABC, abstractmethod
-from typing import Any, Sequence, Literal
+from typing import Any, Callable, Sequence, Literal
 import numpy as np
 from sklearn.base import ClassifierMixin
 from sklearn.exceptions import NotFittedError
@@ -14,7 +14,14 @@ from evedesign.dataset import LabeledInstanceDataset
 from evedesign.system import System, SystemInstance
 from evedesign.model import Transformer, Scorer, SupervisedBaseModel, MutationScorer, \
     ConditionalMutationScorer, assign_scores_to_instances
-from evedesign.types import StatusCallback, ModelStats, BioPolymers, BatchSize
+from evedesign.types import StatusCallback, ModelStats, BioPolymers, BatchSize, DeviceType
+
+try:
+    import torch
+    import gpytorch
+    GPYTORCH_AVAILABLE = True
+except ImportError:
+    GPYTORCH_AVAILABLE = False
 
 spearman_score = lambda y_true, y_pred: spearmanr(y_true, y_pred).correlation
 pearson_score = lambda y_true, y_pred: pearsonr(y_true, y_pred).correlation
@@ -655,3 +662,278 @@ class SklearnPredictorOnEmbeddingsScores(SupervisedPredictorOnEmbeddingsScores):
             return self.predictor.predict(
                 instances_transformed
             ).astype(float)
+
+
+def _build_default_gp(train_x, train_y, likelihood):
+    """
+    Default ExactGP: constant mean + RBF kernel with output scaling,
+    paired w/ supplied likelihood. Used by GpytorchModel when no gp_factory is given
+    """
+    class _DefaultExactGP(gpytorch.models.ExactGP):
+        def __init__(self, train_x, train_y, likelihood):
+            super().__init__(train_x, train_y, likelihood)
+            self.mean_module = gpytorch.means.ConstantMean()
+            self.covar_module = gpytorch.kernels.ScaleKernel(
+                gpytorch.kernels.RBFKernel()
+            )
+
+        def forward(self, x):
+            mean_x = self.mean_module(x)
+            covar_x = self.covar_module(x)
+            return gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
+
+    return _DefaultExactGP(train_x, train_y, likelihood)
+
+
+class GpytorchModel(SupervisedPredictorOnEmbeddingsScores):
+    """
+    Supervised Gaussian process regression on pooled molecular embeddings/scores, backed by gpytorch.
+
+    By passing a gp_factory you can use essentially any exact GP gpytorch supports (arbitrary mean modules, 
+    kernel compositions, multi-task structure, custom forward passes), and train_loop can replace optimization.
+    """
+    available = GPYTORCH_AVAILABLE
+    name: str = "Gaussian process predictor on sequence embeddings/scores"
+    citations: list[str] = ["doi:10.1038/s41587-021-01146-5", "doi:10.48550/arXiv.1809.11165"]
+
+    requires_gpu: bool = False
+    supports_gpu: bool = True
+    supports_gpu_parallel: bool = False
+    supports_cpu_parallel: bool = True
+
+    def __init__(
+        self,
+        gp_factory: Callable[[Any, Any, Any], Any] | None = None,
+        likelihood: Any | Callable[[], Any] | None = None,
+        num_iters: int = 100,
+        learning_rate: float = 0.1,
+        optimizer_cls: Any | None = None,
+        optimizer_kwargs: dict[str, Any] | None = None,
+        mll_cls: Any | None = None,
+        train_loop: Callable[[Any, Any, Any, Any, Any], None] | None = None,
+        standardize_targets: bool = True,
+        device: DeviceType = "cpu",
+        embedder: Transformer | None = None,
+        scorer: Scorer | None = None,
+        use_embeddings: bool = True,
+        use_scores: bool = True,
+        override_models_for_training: bool = False,
+        target_name: str | None = None,
+        pooling: Literal["mean", "max"] | None = "mean",
+        batch_size: BatchSize = 128,
+    ):
+        """
+        Train an exact Gaussian process regression model on top of molecular model embeddings/scores.
+
+        Parameters
+        ----------
+        gp_factory
+            Callable ((train_x, train_y, likelihood) -> gpytorch.models.ExactGP) that builds the GP model
+            from the training tensors and likelihood. If None, a default constant-mean + scaled-RBF ExactGP is used.
+            Hyperparameters are re-initialized for each cross-validation split
+        likelihood
+            gpytorch likelihood to use. If None, a GaussianLikelihood is used
+        num_iters
+            Number of optimizer steps for the default training loop (ignored if train_loop is provided)
+        learning_rate
+            Learning rate for the default optimizer (ignored if train_loop is provided)
+        optimizer_cls
+            torch optimizer class to use for the default training loop, constructed as
+            optimizer_cls(model.parameters(), lr=learning_rate, **optimizer_kwargs). If None, torch.optim.Adam
+        optimizer_kwargs
+            Extra keyword arguments forwarded to the optimizer constructor
+        mll_cls
+            Marginal log-likelihood class, constructed as mll_cls(likelihood, model) and maximized during
+            training. If None, gpytorch.mlls.ExactMarginalLogLikelihood
+        train_loop
+            Optional callable (model, likelihood, train_x, train_y, mll) -> None that replaces the default
+            optimization loop, for complete control over training (schedulers, early stopping, etc.)
+        standardize_targets
+            If True, standardize y to zero mean / unit variance before fitting and invert the transform on
+            predictions
+        device
+            Device on which to place tensors and run inference ("cpu", "cuda" or "mps")
+        embedder, scorer, use_embeddings, use_scores, override_models_for_training, target_name, pooling, batch_size
+            See SupervisedPredictorOnEmbeddingsScores
+        """
+        if not self.available:
+            raise ImportError(
+                "gpytorch package could not be imported"
+                "Install with the optional dependency pip install evedesign[gpytorch]"
+            )
+
+        super().__init__(
+            embedder=embedder,
+            scorer=scorer,
+            use_embeddings=use_embeddings,
+            use_scores=use_scores,
+            override_models_for_training=override_models_for_training,
+            target_name=target_name,
+            pooling=pooling,
+            batch_size=batch_size,
+            is_classifier=False,
+        )
+
+        self.gp_factory = gp_factory
+        self.likelihood_spec = likelihood
+        self.num_iters = num_iters
+        self.learning_rate = learning_rate
+        self.optimizer_cls = optimizer_cls
+        self.optimizer_kwargs = optimizer_kwargs if optimizer_kwargs is not None else {}
+        self.mll_cls = mll_cls
+        self.train_loop = train_loop
+        self.standardize_targets = standardize_targets
+        self.device = device
+
+        # fitted state (set by _fit)
+        self._model = None
+        self._likelihood = None
+        self._y_mean: float = 0.0
+        self._y_std: float = 1.0
+
+    @property
+    def ready(self) -> bool:
+        return self.system is not None and self._model is not None and self._likelihood is not None
+
+    @property
+    def gp_model(self):
+        """Fitted gpytorch ExactGP model (None until build() has been called)"""
+        return self._model
+
+    @property
+    def gp_likelihood(self):
+        """Fitted gpytorch likelihood (None until build() has been called)"""
+        return self._likelihood
+
+    def _make_likelihood(self):
+        spec = self.likelihood_spec
+        if spec is None:
+            return gpytorch.likelihoods.GaussianLikelihood()
+        # an existing likelihood instance is reused as-is, a class/callable is instantiated for a fresh one
+        if isinstance(spec, gpytorch.likelihoods.Likelihood):
+            return spec
+        if callable(spec):
+            return spec()
+        raise ValueError(
+            "likelihood must be a gpytorch Likelihood instance, a callable/class returning one, or None"
+        )
+
+    def _to_tensor(self, array) -> "torch.Tensor":
+        return torch.as_tensor(
+            np.asarray(array), dtype=torch.get_default_dtype(), device=torch.device(self.device)
+        )
+
+    def _fit(
+        self,
+        instances_transformed,
+        values
+    ) -> None:
+        train_x = self._to_tensor(instances_transformed)
+
+        # standardize targets for GP numerical stability; invert on prediction
+        y = np.asarray(values, dtype=float)
+        if self.standardize_targets:
+            self._y_mean = float(y.mean())
+            # guard against constant targets (zero variance)
+            self._y_std = float(y.std()) or 1.0
+        else:
+            self._y_mean, self._y_std = 0.0, 1.0
+
+        train_y = self._to_tensor((y - self._y_mean) / self._y_std)
+
+        # build likelihood and model, move to device
+        device = torch.device(self.device)
+        self._likelihood = self._make_likelihood().to(device)
+
+        if self.gp_factory is not None:
+            self._model = self.gp_factory(train_x, train_y, self._likelihood)
+        else:
+            self._model = _build_default_gp(train_x, train_y, self._likelihood)
+        self._model = self._model.to(device)
+
+        # marginal log-likelihood to maximize during training
+        mll_cls = self.mll_cls if self.mll_cls is not None else gpytorch.mlls.ExactMarginalLogLikelihood
+        mll = mll_cls(self._likelihood, self._model)
+
+        self._model.train()
+        self._likelihood.train()
+
+        if self.train_loop is not None:
+            # hand full control of optimization to the user-supplied loop
+            self.train_loop(self._model, self._likelihood, train_x, train_y, mll)
+        else:
+            optimizer_cls = self.optimizer_cls if self.optimizer_cls is not None else torch.optim.Adam
+            optimizer = optimizer_cls(
+                self._model.parameters(), lr=self.learning_rate, **self.optimizer_kwargs
+            )
+            for _ in range(self.num_iters):
+                optimizer.zero_grad()
+                output = self._model(train_x)
+                loss = -mll(output, train_y)
+                loss.backward()
+                optimizer.step()
+
+        self._model.eval()
+        self._likelihood.eval()
+
+    def _posterior(
+        self,
+        instances_transformed,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Compute posterior predictive mean and standard deviation (on the original target scale)
+        for pre-transformed instances using the fitted GP.
+        """
+        test_x = self._to_tensor(instances_transformed)
+
+        self._model.eval()
+        self._likelihood.eval()
+
+        with torch.no_grad(), gpytorch.settings.fast_pred_var():
+            # pass through likelihood to obtain the predictive distribution
+            posterior = self._likelihood(self._model(test_x))
+            mean = posterior.mean.detach().cpu().numpy().astype(float)
+            std = posterior.stddev.detach().cpu().numpy().astype(float)
+
+        # invert target standardization
+        mean = mean * self._y_std + self._y_mean
+        std = std * self._y_std
+
+        return mean, std
+
+    def _score(
+        self,
+        instances_transformed,
+    ) -> np.ndarray[tuple[int], np.dtype[float]]:
+        # framework score is the posterior predictive mean
+        mean, _ = self._posterior(instances_transformed)
+        return mean
+
+    def predict_with_uncertainty(
+        self,
+        instances: Sequence[SystemInstance],
+        status_callback: StatusCallback | None = None
+    ) -> tuple[np.ndarray[tuple[int], np.dtype[float]], np.ndarray[tuple[int], np.dtype[float]]]:
+        """
+        Predict posterior mean and standard deviation for a batch of instances. This is the GP-specific counterpart to score()
+        that will return the uncertainty componenet
+
+        Parameters
+        ----------
+        instances
+            Designs to predict
+        status_callback
+            Callback function to track computation status
+
+        Returns
+        -------
+        tuple of (mean, std)
+            Posterior predictive mean and standard deviation on the original target scale
+        """
+        self.ready_or_raise()
+
+        x_pred = self._transform_and_validate_instances(
+            instances, override_models=False, status_callback=status_callback
+        )
+
+        return self._posterior(x_pred)


### PR DESCRIPTION
My goal was to basically give the user as much freedom as possible to interact w/ the GPytorch package. GPytorchModel inherits from SupervisedPredictorOnEmbeddingsScores, but is basically constructed from a bunch of user-defined classes ex. a gpytorch.models.ExactGP implementation. 

points for discussion:
1. I could probably move some of the __init__ params to build() (since this is wrapping SupervisedPredictorOnEmbeddingsScores I tried not to add a GP-specific build() fxn and just overwrote _fit)

2. score() does not return uncertainties, wanted to keep it similar to the rest of the models and not have to deal w/ tuples, but this led to the separate predict_with_uncertainty() copy of score