### PR TITLE
Add CI/CD workflows for tests and PyPI releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest build
+
+      - name: Run tests
+        run: pytest tests/
+
+      - name: Verify package build
+        run: python -m build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/evedesign/
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -51,6 +51,31 @@ with BoltzGen or BindCraft.
 We are actively looking for further contributors to develop our framework jointly with the community. 
 If you are interested or feel like an important model is missing from the framework, please get in contact with us!
 
+### Development setup
+
+Contributions should target the `develop` branch. To set up a local environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+python -m pip install --upgrade pip
+python -m pip install -e .
+python -m pip install pytest build
+```
+
+Run the test suite and verify the package builds:
+
+```bash
+pytest tests/
+python -m build
+```
+
+CI runs these checks on pull requests using core dependencies only. Optional model extras (`evmutation2`, `esm2`, `mpnn`, etc.) are not installed in CI because they pull in heavier ML dependencies such as PyTorch.
+
+### Releasing
+
+Tagged releases (`v*`) trigger the release workflow, which builds and publishes to PyPI. Maintainers must configure [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) for this repository before the first automated release.
+
 ## License
 
 *evedesign* is released under the MIT license.


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions CI workflow that runs tests and verifies package builds on pull requests and pushes to `develop` (Python 3.12 and 3.13).
- Adds a release workflow that builds and publishes to PyPI when a `v*` tag is pushed.
- Documents local development setup and release requirements in the README.

Fixes #73

## Test plan
- [x] Ran `pytest tests/` locally on Python 3.12 (2/2 passed)
- [x] Ran `python -m build` locally (sdist + wheel built successfully)
- [ ] CI workflow passes on this PR
- [ ] Maintainers configure [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) before first automated release

## Notes for maintainers
The release workflow uses PyPI trusted publishing (`pypa/gh-action-pypi-publish`). A trusted publisher must be configured on the PyPI project linking to `evedesignbio/evedesign` before tagged releases can publish automatically.